### PR TITLE
Use a NopLogger, since we can't guarantee os.Stdout will be globally …

### DIFF
--- a/wrp/wrpendpoint/requestResponse.go
+++ b/wrp/wrpendpoint/requestResponse.go
@@ -3,14 +3,11 @@ package wrpendpoint
 import (
 	"io"
 	"io/ioutil"
-	"os"
 
 	"github.com/Comcast/webpa-common/tracing"
 	"github.com/Comcast/wrp-go/wrp"
 	"github.com/go-kit/kit/log"
 )
-
-var defaultLogger = log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
 
 // Note is the core type implemented by any entity which carries a WRP message.
 type Note interface {
@@ -104,7 +101,7 @@ func (r *request) Logger() log.Logger {
 		return r.logger
 	}
 
-	return defaultLogger
+	return log.NewNopLogger()
 }
 
 func (r *request) WithLogger(logger log.Logger) Request {


### PR DESCRIPTION
…synchronized