### PR TITLE
Extend adapter and decoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - Changed folder structure to bring go files into the root directory [#32](https://github.com/xmidt-org/wrp-go/pull/32)
 - Updated travis to automate releases [#40](https://github.com/xmidt-org/wrp-go/pull/40)
+- Extend WRPHandler Request Adapter and Decoder [#43](https://github.com/xmidt-org/wrp-go/pull/43)
 
 ## [v1.3.4]
 - Bumped webpa-common to v1.3.2


### PR DESCRIPTION
-Extend wrphttp adapter to include original payload (useful for happy path for users who correctly fill out their WRPs)
-Wrap existing functions to fetch wrp entity from either headers or body