### PR TITLE
bug: Patch outdated error assert for `testWRPHandlerDecodeError`

### DIFF
--- a/wrphttp/errors.go
+++ b/wrphttp/errors.go
@@ -16,6 +16,8 @@
 
 package wrphttp
 
+import "errors"
+
 type httpError struct {
 	err  error
 	code int
@@ -27,4 +29,9 @@ func (e httpError) Error() string {
 
 func (e httpError) StatusCode() int {
 	return e.code
+}
+
+// Is reports whether any error in e.err's chain matches target.
+func (e httpError) Is(target error) bool {
+	return errors.Is(e.err, target)
 }

--- a/wrphttp/handler_test.go
+++ b/wrphttp/handler_test.go
@@ -218,8 +218,12 @@ func testWRPHandlerDecodeError(t *testing.T) {
 			assert.ErrorIs(actualErr, expectedErr,
 				fmt.Errorf("error [%v] doesn't contain error [%v] in its err chain",
 					actualErr, expectedErr))
-			if err, ok := actualErr.(httpError); assert.True(ok) {
-				assert.Equal(err.StatusCode(), expectedHTTPStatusCode)
+
+			var actualErrorHTTP httpError
+			if assert.ErrorAs(actualErr, &actualErrorHTTP,
+				fmt.Errorf("error [%v] doesn't contain error [%v] in its err chain",
+					actualErr, actualErrorHTTP)) {
+				assert.Equal(expectedHTTPStatusCode, actualErrorHTTP.StatusCode())
 			}
 		}
 


### PR DESCRIPTION
## Overview

### tl;rd
Update testWRPHandlerDecodeError to handle its expected error as a httpError.

<details>
<summary> Explanation</summary>

`wrpHandler.ServeHTTP` now returns a 400 httpError when it's decoder returns an error:
https://github.com/xmidt-org/wrp-go/blob/4b275411c7aa52e1a537cc130f3b0f37e526c978/wrphttp/handler.go#L114-L122
But `testWRPHandlerDecodeError` expects the non-httpError version of `actualErr`:
https://github.com/xmidt-org/wrp-go/blob/4b275411c7aa52e1a537cc130f3b0f37e526c978/wrphttp/handler_test.go#L205-L217

</details>

<details>
<summary>Type of Change(s)</summary>

- Bug fix (non-breaking change which fixes an issue)
- All new and existing tests passed.

</details>

<details>
<summary>Module Unit Testing: [100% PASSING]</summary>

Passed all package unit tests.

</details>

<details>
<summary>PR Affecting Unit Testing: handler_test.go [100% PASSING]</summary>

```console
Running tool: /usr/local/bin/go test -timeout 30s -run ^(TestHandlerFunc|TestWithErrorEncoder|TestWithNewResponseWriter|TestWithDecoder|TestWithBefore|TestNewHTTPHandler|TestWRPHandler)$ github.com/xmidt-org/wrp-go/v3/wrphttp

=== RUN   TestHandlerFunc
--- PASS: TestHandlerFunc (0.00s)
=== RUN   TestWithErrorEncoder
=== RUN   TestWithErrorEncoder/Default
=== RUN   TestWithErrorEncoder/Custom
--- PASS: TestWithErrorEncoder (0.00s)
    --- PASS: TestWithErrorEncoder/Default (0.00s)
    --- PASS: TestWithErrorEncoder/Custom (0.00s)
=== RUN   TestWithNewResponseWriter
=== RUN   TestWithNewResponseWriter/Default
=== RUN   TestWithNewResponseWriter/Custom
--- PASS: TestWithNewResponseWriter (0.00s)
    --- PASS: TestWithNewResponseWriter/Default (0.00s)
    --- PASS: TestWithNewResponseWriter/Custom (0.00s)
=== RUN   TestWithDecoder
=== RUN   TestWithDecoder/Default
=== RUN   TestWithDecoder/Custom
--- PASS: TestWithDecoder (0.00s)
    --- PASS: TestWithDecoder/Default (0.00s)
    --- PASS: TestWithDecoder/Custom (0.00s)
=== RUN   TestWithBefore
=== RUN   TestWithBefore/0
=== RUN   TestWithBefore/1
=== RUN   TestWithBefore/2
=== RUN   TestWithBefore/3
--- PASS: TestWithBefore (0.00s)
    --- PASS: TestWithBefore/0 (0.00s)
    --- PASS: TestWithBefore/1 (0.00s)
    --- PASS: TestWithBefore/2 (0.00s)
    --- PASS: TestWithBefore/3 (0.00s)
=== RUN   TestNewHTTPHandler
--- PASS: TestNewHTTPHandler (0.00s)
=== RUN   TestWRPHandler
=== RUN   TestWRPHandler/ServeHTTP
=== RUN   TestWRPHandler/ServeHTTP/DecodeError
=== RUN   TestWRPHandler/ServeHTTP/ResponseWriterError
=== RUN   TestWRPHandler/ServeHTTP/Success
    /Users/odc/Documents/GitHub/xmidt-org/wrp-go/wrphttp/handler_test.go:345: PASS:     ServeWRP(mock.argumentMatcher,mock.argumentMatcher)
--- PASS: TestWRPHandler (0.00s)
    --- PASS: TestWRPHandler/ServeHTTP (0.00s)
        --- PASS: TestWRPHandler/ServeHTTP/DecodeError (0.00s)
        --- PASS: TestWRPHandler/ServeHTTP/ResponseWriterError (0.00s)
        --- PASS: TestWRPHandler/ServeHTTP/Success (0.00s)
PASS
ok      github.com/xmidt-org/wrp-go/v3/wrphttp  0.229s


> Test run finished at 4/26/2022, 2:19:47 PM <
```

</details>