### PR TITLE
Bug: 500 `Invalid WRP content type: */*` for an invalid accept header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix `500 Invalid WRP content type` [#74](https://github.com/xmidt-org/wrp-go/pull/74)
 
 ## [v3.1.2]
 - Move ParseID func and relevant consts from webpa-common to wrp-go. [#75](https://github.com/xmidt-org/wrp-go/pull/75)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Fix `500 Invalid WRP content type` [#74](https://github.com/xmidt-org/wrp-go/pull/74)
+- Fix `500 Invalid WRP content type` for invalid `Accept` headers [#74](https://github.com/xmidt-org/wrp-go/pull/74)
 
 ## [v3.1.2]
 - Move ParseID func and relevant consts from webpa-common to wrp-go. [#75](https://github.com/xmidt-org/wrp-go/pull/75)

--- a/format.go
+++ b/format.go
@@ -109,7 +109,7 @@ func FormatFromContentType(contentType string, fallback ...Format) (Format, erro
 		return Msgpack, nil
 	}
 
-	return Format(-1), fmt.Errorf("Invalid WRP content type: %s", contentType)
+	return Format(-1), fmt.Errorf("invalid WRP content type: %s", contentType)
 }
 
 // handle looks up the appropriate codec.Handle for this format constant.

--- a/wrphttp/decoders.go
+++ b/wrphttp/decoders.go
@@ -42,6 +42,11 @@ func DecodeEntity(defaultFormat wrp.Format) Decoder {
 			return nil, err
 		}
 
+		_, err = DetermineFormat(defaultFormat, original.Header, "Accept")
+		if err != nil {
+			return nil, err
+		}
+
 		contents, err := ioutil.ReadAll(original.Body)
 		if err != nil {
 			return nil, err

--- a/wrphttp/decoders.go
+++ b/wrphttp/decoders.go
@@ -47,11 +47,6 @@ func DecodeEntity(defaultFormat wrp.Format) Decoder {
 			return nil, fmt.Errorf("failed to determine format of Accept header: %v", err)
 		}
 
-		_, err = DetermineFormat(defaultFormat, original.Header, "Accept")
-		if err != nil {
-			return nil, err
-		}
-
 		contents, err := ioutil.ReadAll(original.Body)
 		if err != nil {
 			return nil, err

--- a/wrphttp/decoders.go
+++ b/wrphttp/decoders.go
@@ -47,6 +47,11 @@ func DecodeEntity(defaultFormat wrp.Format) Decoder {
 			return nil, fmt.Errorf("failed to determine format of Accept header: %v", err)
 		}
 
+		_, err = DetermineFormat(defaultFormat, original.Header, "Accept")
+		if err != nil {
+			return nil, err
+		}
+
 		contents, err := ioutil.ReadAll(original.Body)
 		if err != nil {
 			return nil, err

--- a/wrphttp/decoders.go
+++ b/wrphttp/decoders.go
@@ -39,12 +39,12 @@ func DecodeEntity(defaultFormat wrp.Format) Decoder {
 	return func(ctx context.Context, original *http.Request) (*Entity, error) {
 		format, err := DetermineFormat(defaultFormat, original.Header, "Content-Type")
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to determine format of Content-Type header: %v", err)
 		}
 
 		_, err = DetermineFormat(defaultFormat, original.Header, "Accept")
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to determine format of Accept header: %v", err)
 		}
 
 		contents, err := ioutil.ReadAll(original.Body)

--- a/wrphttp/decoders_test.go
+++ b/wrphttp/decoders_test.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"net/http/httptest"
 	"testing"
 

--- a/wrphttp/decoders_test.go
+++ b/wrphttp/decoders_test.go
@@ -103,7 +103,7 @@ func testDecodeEntityInvalidContentType(t *testing.T) {
 	}
 
 	for _, record := range testData {
-		t.Run(fmt.Sprintf("test case: %v", record.name), func(t *testing.T) {
+		t.Run(record.name, func(t *testing.T) {
 			var (
 				assert  = assert.New(t)
 				require = require.New(t)

--- a/wrphttp/decoders_test.go
+++ b/wrphttp/decoders_test.go
@@ -21,8 +21,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,15 +40,22 @@ func testDecodeEntitySuccess(t *testing.T) {
 		defaultFormat wrp.Format
 		bodyFormat    wrp.Format
 		contentType   string
+		accept        string
+		name          string
 	}{
-		{wrp.Msgpack, wrp.Msgpack, ""},
-		{wrp.JSON, wrp.JSON, ""},
-		{wrp.Msgpack, wrp.JSON, wrp.JSON.ContentType()},
-		{wrp.JSON, wrp.Msgpack, wrp.Msgpack.ContentType()},
+		// Default test cases
+		{wrp.Msgpack, wrp.Msgpack, "", "", "default WRP headers"},
+		{wrp.JSON, wrp.JSON, "", "", "default JSON headers"},
+		// Accept header test cases
+		{wrp.JSON, wrp.JSON, "", wrp.JSON.ContentType(), "JSON Accept header"},
+		{wrp.JSON, wrp.JSON, "", wrp.Msgpack.ContentType(), "WRP Accept header"},
+		// Content-Type header test cases
+		{wrp.Msgpack, wrp.JSON, wrp.JSON.ContentType(), "", "JSON Content-Type header"},
+		{wrp.JSON, wrp.Msgpack, wrp.Msgpack.ContentType(), "", "WRP Content-Type header"},
 	}
 
-	for i, record := range testData {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
+	for _, record := range testData {
+		t.Run(fmt.Sprintf("test case: %v", record.name), func(t *testing.T) {
 			var (
 				assert  = assert.New(t)
 				require = require.New(t)
@@ -71,6 +78,7 @@ func testDecodeEntitySuccess(t *testing.T) {
 			request := httptest.NewRequest("POST", "/", bytes.NewBuffer(body))
 
 			request.Header.Set("Content-Type", record.contentType)
+			request.Header.Set("Accept", record.accept)
 			entity, err := decoder(context.Background(), request)
 			assert.NoError(err)
 			require.NotNil(entity)
@@ -83,19 +91,34 @@ func testDecodeEntitySuccess(t *testing.T) {
 }
 
 func testDecodeEntityInvalidContentType(t *testing.T) {
-	var (
-		assert  = assert.New(t)
-		require = require.New(t)
+	testData := []struct {
+		contentType string
+		accept      string
+		name        string
+	}{
+		// Content-Type header test cases
+		{"invalid", "", "Content-Type Header"},
+		// Accept Header test cases
+		{"", "invalid", "Accept Header"},
+	}
 
-		decoder = DecodeEntity(wrp.Msgpack)
-		request = httptest.NewRequest("GET", "/", nil)
-	)
+	for _, record := range testData {
+		t.Run(fmt.Sprintf("test case: %v", record.name), func(t *testing.T) {
+			var (
+				assert  = assert.New(t)
+				require = require.New(t)
 
-	require.NotNil(decoder)
-	request.Header.Set("Content-Type", "invalid")
-	entity, err := decoder(context.Background(), request)
-	assert.Nil(entity)
-	assert.Error(err)
+				decoder = DecodeEntity(wrp.Msgpack)
+				request = httptest.NewRequest("GET", "/", nil)
+			)
+			require.NotNil(decoder)
+			request.Header.Set("Content-Type", record.contentType)
+			request.Header.Set("Accept", record.accept)
+			entity, err := decoder(context.Background(), request)
+			assert.Nil(entity)
+			assert.Error(err)
+		})
+	}
 }
 
 func testDecodeEntityBodyError(t *testing.T) {

--- a/wrphttp/decoders_test.go
+++ b/wrphttp/decoders_test.go
@@ -55,7 +55,7 @@ func testDecodeEntitySuccess(t *testing.T) {
 	}
 
 	for _, record := range testData {
-		t.Run(fmt.Sprintf("test case: %v", record.name), func(t *testing.T) {
+		t.Run(record.name, func(t *testing.T) {
 			var (
 				assert  = assert.New(t)
 				require = require.New(t)


### PR DESCRIPTION
## Overview

related to xmidt-org/talaria#227 where a `500 Invalid WRP content type: */*` is produced when an invalid accept header is provided. Instead of a 500, 400 is now returned.

### tl;rd
This patches the bug where replacing the header Accept: application/json with anything except application/json like Accept: */*, returns a 500 Invalid WRP content type: */*.

<details>
<summary> Explanation</summary>

It starts off with an error from `DetermineFormat` not being handled at
https://github.com/xmidt-org/wrp-go/blob/4b275411c7aa52e1a537cc130f3b0f37e526c978/wrphttp/requestResponse.go#L140-L143

Then `NewEntityResponseWriter`s `DetermineFormat error` gets handled as a `500` at
https://github.com/xmidt-org/wrp-go/blob/4b275411c7aa52e1a537cc130f3b0f37e526c978/wrphttp/handler.go#L134-L138


</details>

<details>
<summary>Type of Change(s)</summary>

- Bug fix (non-breaking change which fixes an issue)
- All new and existing tests passed.

</details>

<details>
<summary>Module Unit Testing: [PASSING]</summary>


</details>

<details>
<summary>PR Affecting Unit Testing: handler_test.go [PASSING]</summary>

```console
Running tool: /usr/local/bin/go test -timeout 30s -run ^(TestHandlerFunc|TestWithErrorEncoder|TestWithNewResponseWriter|TestWithDecoder|TestWithBefore|TestNewHTTPHandler|TestWRPHandler)$ github.com/xmidt-org/wrp-go/v3/wrphttp

=== RUN   TestHandlerFunc
--- PASS: TestHandlerFunc (0.00s)
=== RUN   TestWithErrorEncoder
=== RUN   TestWithErrorEncoder/Default
=== RUN   TestWithErrorEncoder/Custom
--- PASS: TestWithErrorEncoder (0.00s)
    --- PASS: TestWithErrorEncoder/Default (0.00s)
    --- PASS: TestWithErrorEncoder/Custom (0.00s)
=== RUN   TestWithNewResponseWriter
=== RUN   TestWithNewResponseWriter/Default
=== RUN   TestWithNewResponseWriter/Custom
--- PASS: TestWithNewResponseWriter (0.00s)
    --- PASS: TestWithNewResponseWriter/Default (0.00s)
    --- PASS: TestWithNewResponseWriter/Custom (0.00s)
=== RUN   TestWithDecoder
=== RUN   TestWithDecoder/Default
=== RUN   TestWithDecoder/Custom
--- PASS: TestWithDecoder (0.00s)
    --- PASS: TestWithDecoder/Default (0.00s)
    --- PASS: TestWithDecoder/Custom (0.00s)
=== RUN   TestWithBefore
=== RUN   TestWithBefore/0
=== RUN   TestWithBefore/1
=== RUN   TestWithBefore/2
=== RUN   TestWithBefore/3
--- PASS: TestWithBefore (0.00s)
    --- PASS: TestWithBefore/0 (0.00s)
    --- PASS: TestWithBefore/1 (0.00s)
    --- PASS: TestWithBefore/2 (0.00s)
    --- PASS: TestWithBefore/3 (0.00s)
=== RUN   TestNewHTTPHandler
--- PASS: TestNewHTTPHandler (0.00s)
=== RUN   TestWRPHandler
=== RUN   TestWRPHandler/ServeHTTP
=== RUN   TestWRPHandler/ServeHTTP/DecodeError
=== RUN   TestWRPHandler/ServeHTTP/ResponseWriterError
=== RUN   TestWRPHandler/ServeHTTP/Success
    /Users/odc/Documents/GitHub/xmidt-org/wrp-go/wrphttp/handler_test.go:352: PASS:     ServeWRP(mock.argumentMatcher,mock.argumentMatcher)
--- PASS: TestWRPHandler (0.00s)
    --- PASS: TestWRPHandler/ServeHTTP (0.00s)
        --- PASS: TestWRPHandler/ServeHTTP/DecodeError (0.00s)
        --- PASS: TestWRPHandler/ServeHTTP/ResponseWriterError (0.00s)
        --- PASS: TestWRPHandler/ServeHTTP/Success (0.00s)
PASS
ok      github.com/xmidt-org/wrp-go/v3/wrphttp  0.134s


> Test run finished at 5/2/2022, 3:47:48 PM <
```

</details>


## Local Test
Ran talaria locally
```console
curl -v --location --request POST 'localhost:6200/api/v3/device/send' \
--header 'Content-Type: application/json' \
--header 'Authorization: Basic dXNlcjpwYXNz' \
--data-raw '{
"msg_type":3,
"content_type":"application/json",
"source":"dns:me",
"dest":"mac:112233445566",
"transaction_uuid":"1234567890",
"payload":"eyJjb21tYW5kIjoiR0VUIiwibmFtZXMiOlsiU29tZXRoaW5nIl19",
"partner_ids":["comcast"]
}'

# Output:

Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1:6200...
* Connected to localhost (127.0.0.1) port 6200 (#0)
> POST /api/v3/device/send HTTP/1.1
> Host: localhost:6200
> User-Agent: curl/7.79.1
> Accept: */*
> Content-Type: application/json
> Authorization: Basic dXNlcjpwYXNz
> Content-Length: 223
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 400 Bad Request
< Content-Length: 29
< Content-Type: text/plain; charset=utf-8
< X-Talaria-Build: 0.1.4
< X-Talaria-Flavor: mint
< X-Talaria-Region: east
< X-Talaria-Server: talaria
< X-Talaria-Start-Time: 26 Apr 22 15:51 UTC
< Date: Tue, 26 Apr 2022 16:03:41 GMT
<
* Connection #0 to host localhost left intact
Invalid WRP content type: */*%
#
```