### PR TITLE
FR: Initial WRP Validation Framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ report.json
 
 # Images
 *.png
+
+# VSCode
+*.code-workspace
+.vscode/*

--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,5 @@ require (
 	github.com/ugorji/go/codec v1.2.6
 	github.com/xmidt-org/httpaux v0.3.0
 	github.com/xmidt-org/webpa-common v1.3.2
+	go.uber.org/multierr v1.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,10 @@ github.com/xmidt-org/httpaux v0.3.0 h1:JdV4QceiE8EMA1Qf5rnJzHdkIPzQV12ddARHLU8hr
 github.com/xmidt-org/httpaux v0.3.0/go.mod h1:mviIlg5fHGb3lAv3l0sbiwVG/q9rqvXaudEYxVrzXdE=
 github.com/xmidt-org/webpa-common v1.3.2 h1:dE1Fi+XVnkt3tMGMjH7/hN/UGcaQ/ukKriXuMDyCWnM=
 github.com/xmidt-org/webpa-common v1.3.2/go.mod h1:oCpKzOC+9h2vYHVzAU/06tDTQuBN4RZz+rhgIXptpOI=
+go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
+go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/multierr v1.8.0 h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
+go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/header_wrp.go
+++ b/header_wrp.go
@@ -30,8 +30,6 @@ const (
 	SourceHeader          = "X-Midt-Source"
 )
 
-// var ErrInvalidMsgType = errors.New("Invalid Message Type")
-
 // Map string to MessageType int
 /*
 func StringToMessageType(str string) MessageType {

--- a/header_wrp.go
+++ b/header_wrp.go
@@ -17,10 +17,6 @@
 
 package wrp
 
-import (
-	"errors"
-)
-
 // Constant HTTP header strings representing WRP fields
 const (
 	MsgTypeHeader         = "X-Midt-Msg-Type"
@@ -34,7 +30,7 @@ const (
 	SourceHeader          = "X-Midt-Source"
 )
 
-var ErrInvalidMsgType = errors.New("Invalid Message Type")
+// var ErrInvalidMsgType = errors.New("Invalid Message Type")
 
 // Map string to MessageType int
 /*

--- a/validator.go
+++ b/validator.go
@@ -1,0 +1,93 @@
+/**
+ *  Copyright (c) 2022  Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wrp
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrInvalidMsgTypeValidator = errors.New("invalid WRP message type validator")
+	ErrInvalidMsgType          = errors.New("invalid WRP message type")
+)
+
+// Validator is a WRP validator that allows access to the Validate function.
+type Validator interface {
+	Validate(m Message) error
+}
+
+// Validators is a WRP validator that ensures messages are valid based on
+// message type and each validator in the list.
+type Validators []Validator
+
+// ValidatorFunc is a WRP validator that takes messages and validates them
+// against functions.
+type ValidatorFunc func(Message) error
+
+// Validate executes its own ValidatorFunc receiver and returns the result.
+func (vf ValidatorFunc) Validate(m Message) error {
+	return vf(m)
+}
+
+// MsgTypeValidator is a WRP validator that validates based on message type
+// or using the defaultValidator if message type is unknown
+type MsgTypeValidator struct {
+	m                map[MessageType]Validators
+	defaultValidator Validator
+}
+
+// Validate validates messages based on message type or using the defaultValidator
+// if message type is unknown
+func (m MsgTypeValidator) Validate(msg Message) error {
+	vs, ok := m.m[msg.MessageType()]
+	if !ok {
+		return m.defaultValidator.Validate(msg)
+	}
+
+	for _, v := range vs {
+		err := v.Validate(msg)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// NewMsgTypeValidator returns a MsgTypeValidator
+func NewMsgTypeValidator(m map[MessageType]Validators, defaultValidator Validator) (MsgTypeValidator, error) {
+	if m == nil {
+		return MsgTypeValidator{}, fmt.Errorf("%w: %v", ErrInvalidMsgTypeValidator, m)
+	}
+	if defaultValidator == nil {
+		defaultValidator = alwaysInvalidMsg()
+	}
+
+	return MsgTypeValidator{
+		m:                m,
+		defaultValidator: defaultValidator,
+	}, nil
+}
+
+// AlwaysInvalid doesn't validate anything about the message and always returns an error.
+func alwaysInvalidMsg() ValidatorFunc {
+	return func(m Message) error {
+		return fmt.Errorf("%w: %v", ErrInvalidMsgType, m.MessageType().String())
+	}
+}

--- a/validator.go
+++ b/validator.go
@@ -86,9 +86,15 @@ func NewTypeValidator(m map[MessageType]Validators, defaultValidator Validator) 
 		return TypeValidator{}, ErrInvalidTypeValidator
 	}
 
-	for _, v := range m {
-		if v == nil || len(v) == 0 {
+	for _, vs := range m {
+		if vs == nil || len(vs) == 0 {
 			return TypeValidator{}, ErrInvalidTypeValidator
+		}
+
+		for _, v := range vs {
+			if v == nil {
+				return TypeValidator{}, ErrInvalidTypeValidator
+			}
 		}
 	}
 

--- a/validator.go
+++ b/validator.go
@@ -19,7 +19,6 @@ package wrp
 
 import (
 	"errors"
-	"fmt"
 )
 
 var (
@@ -29,7 +28,7 @@ var (
 
 // AlwaysInvalid doesn't validate anything about the message and always returns an error.
 var AlwaysInvalidMsg ValidatorFunc = func(m Message) error {
-	return fmt.Errorf("%w: %v", ErrInvalidMsgType, m.MessageType().String())
+	return ErrInvalidMsgType
 }
 
 // Validator is a WRP validator that allows access to the Validate function.
@@ -78,7 +77,7 @@ func (m MsgTypeValidator) Validate(msg Message) error {
 // NewMsgTypeValidator is a MsgTypeValidator factory.
 func NewMsgTypeValidator(m map[MessageType]Validators, defaultValidator Validator) (MsgTypeValidator, error) {
 	if m == nil {
-		return MsgTypeValidator{}, fmt.Errorf("%w: %v", ErrInvalidMsgTypeValidator, m)
+		return MsgTypeValidator{}, ErrInvalidMsgTypeValidator
 	}
 
 	if defaultValidator == nil {

--- a/validator.go
+++ b/validator.go
@@ -75,6 +75,7 @@ func NewMsgTypeValidator(m map[MessageType]Validators, defaultValidator Validato
 	if m == nil {
 		return MsgTypeValidator{}, fmt.Errorf("%w: %v", ErrInvalidMsgTypeValidator, m)
 	}
+
 	if defaultValidator == nil {
 		defaultValidator = alwaysInvalidMsg()
 	}

--- a/validator.go
+++ b/validator.go
@@ -28,7 +28,7 @@ var (
 )
 
 // AlwaysInvalid doesn't validate anything about the message and always returns an error.
-var alwaysInvalidMsg ValidatorFunc = func(m Message) error {
+var AlwaysInvalidMsg ValidatorFunc = func(m Message) error {
 	return fmt.Errorf("%w: %v", ErrInvalidMsgType, m.MessageType().String())
 }
 
@@ -51,14 +51,14 @@ func (vf ValidatorFunc) Validate(m Message) error {
 }
 
 // MsgTypeValidator is a WRP validator that validates based on message type
-// or using the defaultValidator if message type is unknown
+// or using the defaultValidator if message type is unknown.
 type MsgTypeValidator struct {
 	m                map[MessageType]Validators
 	defaultValidator Validator
 }
 
 // Validate validates messages based on message type or using the defaultValidator
-// if message type is unknown
+// if message type is unknown.
 func (m MsgTypeValidator) Validate(msg Message) error {
 	vs, ok := m.m[msg.MessageType()]
 	if !ok {
@@ -75,14 +75,14 @@ func (m MsgTypeValidator) Validate(msg Message) error {
 	return nil
 }
 
-// NewMsgTypeValidator returns a MsgTypeValidator
+// NewMsgTypeValidator is a MsgTypeValidator factory.
 func NewMsgTypeValidator(m map[MessageType]Validators, defaultValidator Validator) (MsgTypeValidator, error) {
 	if m == nil {
 		return MsgTypeValidator{}, fmt.Errorf("%w: %v", ErrInvalidMsgTypeValidator, m)
 	}
 
 	if defaultValidator == nil {
-		defaultValidator = alwaysInvalidMsg
+		defaultValidator = AlwaysInvalidMsg
 	}
 
 	return MsgTypeValidator{

--- a/validator.go
+++ b/validator.go
@@ -27,6 +27,11 @@ var (
 	ErrInvalidMsgType          = errors.New("invalid WRP message type")
 )
 
+// AlwaysInvalid doesn't validate anything about the message and always returns an error.
+var alwaysInvalidMsg ValidatorFunc = func(m Message) error {
+	return fmt.Errorf("%w: %v", ErrInvalidMsgType, m.MessageType().String())
+}
+
 // Validator is a WRP validator that allows access to the Validate function.
 type Validator interface {
 	Validate(m Message) error
@@ -77,18 +82,11 @@ func NewMsgTypeValidator(m map[MessageType]Validators, defaultValidator Validato
 	}
 
 	if defaultValidator == nil {
-		defaultValidator = alwaysInvalidMsg()
+		defaultValidator = alwaysInvalidMsg
 	}
 
 	return MsgTypeValidator{
 		m:                m,
 		defaultValidator: defaultValidator,
 	}, nil
-}
-
-// AlwaysInvalid doesn't validate anything about the message and always returns an error.
-func alwaysInvalidMsg() ValidatorFunc {
-	return func(m Message) error {
-		return fmt.Errorf("%w: %v", ErrInvalidMsgType, m.MessageType().String())
-	}
 }

--- a/validator.go
+++ b/validator.go
@@ -67,35 +67,35 @@ func (vf ValidatorFunc) Validate(m Message) error {
 }
 
 // TypeValidator is a WRP validator that validates based on message type
-// or using the defaultValidators if message type is unfound.
+// or using the defaultValidator if message type is unfound.
 type TypeValidator struct {
-	m                 map[MessageType]Validator
-	defaultValidators Validator
+	m                map[MessageType]Validator
+	defaultValidator Validator
 }
 
-// Validate validates messages based on message type or using the defaultValidators
+// Validate validates messages based on message type or using the defaultValidator
 // if message type is unfound.
 func (m TypeValidator) Validate(msg Message) error {
 	vs := m.m[msg.MessageType()]
 	if vs == nil {
-		return m.defaultValidators.Validate(msg)
+		return m.defaultValidator.Validate(msg)
 	}
 
 	return vs.Validate(msg)
 }
 
 // NewTypeValidator is a TypeValidator factory.
-func NewTypeValidator(m map[MessageType]Validator, defaultValidators ...Validator) (TypeValidator, error) {
+func NewTypeValidator(m map[MessageType]Validator, defaultValidator Validator) (TypeValidator, error) {
 	if m == nil {
 		return TypeValidator{}, ErrInvalidValidator
 	}
 
-	if defaultValidators == nil {
-		defaultValidators = Validators{AlwaysInvalid}
+	if defaultValidator == nil {
+		defaultValidator = AlwaysInvalid
 	}
 
 	return TypeValidator{
-		m:                 m,
-		defaultValidators: Validators(defaultValidators),
+		m:                m,
+		defaultValidator: defaultValidator,
 	}, nil
 }

--- a/validator.go
+++ b/validator.go
@@ -71,16 +71,11 @@ func (vf ValidatorFunc) Validate(m Message) error {
 type TypeValidator struct {
 	m                 map[MessageType]Validator
 	defaultValidators Validator
-	isbad             bool
 }
 
 // Validate validates messages based on message type or using the defaultValidators
 // if message type is unfound.
 func (m TypeValidator) Validate(msg Message) error {
-	if m.isbad {
-		return ErrInvalidTypeValidator
-	}
-
 	vs := m.m[msg.MessageType()]
 	if vs == nil {
 		return m.defaultValidators.Validate(msg)
@@ -89,15 +84,10 @@ func (m TypeValidator) Validate(msg Message) error {
 	return vs.Validate(msg)
 }
 
-// IsBad returns a boolean indicating whether the TypeValidator receiver is valid
-func (m TypeValidator) IsBad() bool {
-	return m.isbad
-}
-
 // NewTypeValidator is a TypeValidator factory.
 func NewTypeValidator(m map[MessageType]Validator, defaultValidators ...Validator) (TypeValidator, error) {
 	if m == nil {
-		return TypeValidator{isbad: true}, ErrInvalidValidator
+		return TypeValidator{}, ErrInvalidValidator
 	}
 
 	if defaultValidators == nil {

--- a/validator.go
+++ b/validator.go
@@ -19,6 +19,8 @@ package wrp
 
 import (
 	"errors"
+
+	"go.uber.org/multierr"
 )
 
 var (
@@ -27,9 +29,10 @@ var (
 )
 
 // AlwaysInvalid doesn't validate anything about the message and always returns an error.
-var AlwaysInvalid ValidatorFunc = func(m Message) error {
-	return ErrInvalidMsgType
-}
+var AlwaysInvalid ValidatorFunc = func(m Message) error { return ErrInvalidMsgType }
+
+// AlwaysValid doesn't validate anything about the message and always returns nil.
+var AlwaysValid ValidatorFunc = func(msg Message) error { return nil }
 
 // Validator is a WRP validator that allows access to the Validate function.
 type Validator interface {
@@ -43,14 +46,12 @@ type Validators []Validator
 // Validate runs messages through each validator in the validators list.
 // It returns as soon as the message is considered invalid, otherwise returns nil if valid.
 func (vs Validators) Validate(m Message) error {
+	var err error
 	for _, v := range vs {
-		err := v.Validate(m)
-		if err != nil {
-			return err
-		}
+		err = multierr.Append(err, v.Validate(m))
 	}
 
-	return nil
+	return err
 }
 
 // ValidatorFunc is a WRP validator that takes messages and validates them
@@ -63,14 +64,14 @@ func (vf ValidatorFunc) Validate(m Message) error {
 }
 
 // TypeValidator is a WRP validator that validates based on message type
-// or using the defaultValidators if message type is unknown.
+// or using the defaultValidators if message type is unfound.
 type TypeValidator struct {
-	m                 map[MessageType]Validators
+	m                 map[MessageType]Validator
 	defaultValidators Validators
 }
 
 // Validate validates messages based on message type or using the defaultValidators
-// if message type is unknown.
+// if message type is unfound.
 func (m TypeValidator) Validate(msg Message) error {
 	vs := m.m[msg.MessageType()]
 	if vs == nil {
@@ -81,20 +82,14 @@ func (m TypeValidator) Validate(msg Message) error {
 }
 
 // NewTypeValidator is a TypeValidator factory.
-func NewTypeValidator(m map[MessageType]Validators, defaultValidators ...Validator) (TypeValidator, error) {
+func NewTypeValidator(m map[MessageType]Validator, defaultValidators ...Validator) (TypeValidator, error) {
 	if m == nil {
 		return TypeValidator{}, ErrInvalidTypeValidator
 	}
 
-	for _, vs := range m {
-		if vs == nil || len(vs) == 0 {
-			return TypeValidator{}, ErrInvalidTypeValidator
-		}
-
-		for _, v := range vs {
-			if v == nil {
-				return TypeValidator{}, ErrInvalidTypeValidator
-			}
+	for _, v := range m {
+		if err := validateValidator(v); err != nil {
+			return TypeValidator{}, err
 		}
 	}
 
@@ -103,8 +98,8 @@ func NewTypeValidator(m map[MessageType]Validators, defaultValidators ...Validat
 	}
 
 	for _, v := range defaultValidators {
-		if v == nil {
-			return TypeValidator{}, ErrInvalidTypeValidator
+		if err := validateValidator(v); err != nil {
+			return TypeValidator{}, err
 		}
 	}
 
@@ -112,4 +107,26 @@ func NewTypeValidator(m map[MessageType]Validators, defaultValidators ...Validat
 		m:                 m,
 		defaultValidators: defaultValidators,
 	}, nil
+}
+
+// validateValidator validates a given Validator.
+func validateValidator(v Validator) error {
+	switch vs := v.(type) {
+	case Validators:
+		if vs == nil || len(vs) == 0 {
+			return ErrInvalidTypeValidator
+		}
+
+		for _, v := range vs {
+			if v == nil {
+				return ErrInvalidTypeValidator
+			}
+		}
+	case Validator, ValidatorFunc:
+	// catch nil Validator
+	default:
+		return ErrInvalidTypeValidator
+	}
+
+	return nil
 }

--- a/validator.go
+++ b/validator.go
@@ -24,7 +24,8 @@ import (
 )
 
 var (
-	ErrInvalidTypeValidator = errors.New("invalid WRP message type validator")
+	ErrInvalidTypeValidator = errors.New("invalid TypeValidator")
+	ErrInvalidValidator     = errors.New("invalid WRP message type validator")
 	ErrInvalidMsgType       = errors.New("invalid WRP message type")
 )
 
@@ -48,7 +49,9 @@ type Validators []Validator
 func (vs Validators) Validate(m Message) error {
 	var err error
 	for _, v := range vs {
-		err = multierr.Append(err, v.Validate(m))
+		if v != nil {
+			err = multierr.Append(err, v.Validate(m))
+		}
 	}
 
 	return err
@@ -67,12 +70,17 @@ func (vf ValidatorFunc) Validate(m Message) error {
 // or using the defaultValidators if message type is unfound.
 type TypeValidator struct {
 	m                 map[MessageType]Validator
-	defaultValidators Validators
+	defaultValidators Validator
+	isbad             bool
 }
 
 // Validate validates messages based on message type or using the defaultValidators
 // if message type is unfound.
 func (m TypeValidator) Validate(msg Message) error {
+	if m.isbad {
+		return ErrInvalidTypeValidator
+	}
+
 	vs := m.m[msg.MessageType()]
 	if vs == nil {
 		return m.defaultValidators.Validate(msg)
@@ -81,52 +89,23 @@ func (m TypeValidator) Validate(msg Message) error {
 	return vs.Validate(msg)
 }
 
+// IsBad returns a boolean indicating whether the TypeValidator receiver is valid
+func (m TypeValidator) IsBad() bool {
+	return m.isbad
+}
+
 // NewTypeValidator is a TypeValidator factory.
 func NewTypeValidator(m map[MessageType]Validator, defaultValidators ...Validator) (TypeValidator, error) {
 	if m == nil {
-		return TypeValidator{}, ErrInvalidTypeValidator
+		return TypeValidator{isbad: true}, ErrInvalidValidator
 	}
 
-	for _, v := range m {
-		if err := validateValidator(v); err != nil {
-			return TypeValidator{}, err
-		}
-	}
-
-	if len(defaultValidators) == 0 {
+	if defaultValidators == nil {
 		defaultValidators = Validators{AlwaysInvalid}
-	}
-
-	for _, v := range defaultValidators {
-		if err := validateValidator(v); err != nil {
-			return TypeValidator{}, err
-		}
 	}
 
 	return TypeValidator{
 		m:                 m,
-		defaultValidators: defaultValidators,
+		defaultValidators: Validators(defaultValidators),
 	}, nil
-}
-
-// validateValidator validates a given Validator.
-func validateValidator(v Validator) error {
-	switch vs := v.(type) {
-	case Validators:
-		if vs == nil || len(vs) == 0 {
-			return ErrInvalidTypeValidator
-		}
-
-		for _, v := range vs {
-			if v == nil {
-				return ErrInvalidTypeValidator
-			}
-		}
-	case Validator, ValidatorFunc:
-	// catch nil Validator
-	default:
-		return ErrInvalidTypeValidator
-	}
-
-	return nil
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -312,7 +312,7 @@ func testAlwaysValid(t *testing.T) {
 			msg: Message{
 				Type:                    SimpleRequestResponseMessageType,
 				Source:                  "external.com",
-				Destination:             "mac:FFEEAADD44443333",
+				Destination:             "MAC:11:22:33:44:55:66",
 				TransactionUUID:         "DEADBEEF",
 				ContentType:             "ContentType",
 				Accept:                  "Accept",
@@ -339,7 +339,7 @@ func testAlwaysValid(t *testing.T) {
 			msg: Message{
 				Type:        lastMessageType,
 				Source:      "external.com",
-				Destination: "mac:FFEEAADD44443333",
+				Destination: "MAC:11:22:33:44:55:66",
 			},
 		},
 	}
@@ -394,7 +394,7 @@ func testAlwaysInvalid(t *testing.T) {
 			msg: Message{
 				Type:                    SimpleRequestResponseMessageType,
 				Source:                  "external.com",
-				Destination:             "mac:FFEEAADD44443333",
+				Destination:             "MAC:11:22:33:44:55:66",
 				TransactionUUID:         "DEADBEEF",
 				ContentType:             "ContentType",
 				Accept:                  "Accept",
@@ -421,7 +421,7 @@ func testAlwaysInvalid(t *testing.T) {
 			msg: Message{
 				Type:        lastMessageType,
 				Source:      "external.com",
-				Destination: "mac:FFEEAADD44443333",
+				Destination: "MAC:11:22:33:44:55:66",
 			},
 		},
 	}

--- a/validator_test.go
+++ b/validator_test.go
@@ -287,7 +287,7 @@ func testAlwaysValid(t *testing.T) {
 			description: "Not UTF8 success",
 			msg: Message{
 				Type:   SimpleRequestResponseMessageType,
-				Source: "external.com",
+				Source: "dns:external.com",
 				// Not UFT8 Destination string
 				Destination:             "mac:\xed\xbf\xbf",
 				TransactionUUID:         "DEADBEEF",
@@ -307,11 +307,12 @@ func testAlwaysValid(t *testing.T) {
 				SessionID:               "sessionID123",
 			},
 		},
+		// Failure case
 		{
 			description: "Filled message success",
 			msg: Message{
 				Type:                    SimpleRequestResponseMessageType,
-				Source:                  "external.com",
+				Source:                  "dns:external.com",
 				Destination:             "MAC:11:22:33:44:55:66",
 				TransactionUUID:         "DEADBEEF",
 				ContentType:             "ContentType",
@@ -338,7 +339,7 @@ func testAlwaysValid(t *testing.T) {
 			description: "Bad message type success",
 			msg: Message{
 				Type:        lastMessageType + 1,
-				Source:      "external.com",
+				Source:      "dns:external.com",
 				Destination: "MAC:11:22:33:44:55:66",
 			},
 		},
@@ -369,7 +370,7 @@ func testAlwaysInvalid(t *testing.T) {
 			description: "Not UTF8 error",
 			msg: Message{
 				Type:   SimpleRequestResponseMessageType,
-				Source: "external.com",
+				Source: "dns:external.com",
 				// Not UFT8 Destination string
 				Destination:             "mac:\xed\xbf\xbf",
 				TransactionUUID:         "DEADBEEF",
@@ -393,7 +394,7 @@ func testAlwaysInvalid(t *testing.T) {
 			description: "Filled message error",
 			msg: Message{
 				Type:                    SimpleRequestResponseMessageType,
-				Source:                  "external.com",
+				Source:                  "dns:external.com",
 				Destination:             "MAC:11:22:33:44:55:66",
 				TransactionUUID:         "DEADBEEF",
 				ContentType:             "ContentType",
@@ -420,7 +421,7 @@ func testAlwaysInvalid(t *testing.T) {
 			description: "Bad message type error",
 			msg: Message{
 				Type:        lastMessageType + 1,
-				Source:      "external.com",
+				Source:      "dns:external.com",
 				Destination: "MAC:11:22:33:44:55:66",
 			},
 		},
@@ -430,7 +431,7 @@ func testAlwaysInvalid(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
 			err := AlwaysInvalid.Validate(tc.msg)
-			assert.Error(err)
+			assert.ErrorIs(err, ErrInvalidMsgType)
 		})
 	}
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -61,7 +61,7 @@ func testMsgTypeValidatorValidate(t *testing.T) {
 			description: "known message type with failing Validators",
 			value: Test{
 				m: map[MessageType]Validators{
-					SimpleEventMessageType: {alwaysInvalidMsg()},
+					SimpleEventMessageType: {alwaysInvalidMsg},
 				},
 				msg: Message{Type: SimpleEventMessageType},
 			},
@@ -162,10 +162,7 @@ func testNewMsgTypeValidator(t *testing.T) {
 func testAlwaysInvalidMsg(t *testing.T) {
 	assert := assert.New(t)
 	msg := Message{}
-	v := alwaysInvalidMsg()
-
-	assert.NotNil(v)
-	err := v(msg)
+	err := alwaysInvalidMsg(msg)
 
 	assert.NotNil(err)
 	assert.ErrorIs(err, ErrInvalidMsgType)

--- a/validator_test.go
+++ b/validator_test.go
@@ -1,0 +1,199 @@
+/**
+ *  Copyright (c) 2022  Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package wrp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func testMsgTypeValidatorValidate(t *testing.T) {
+	type Test struct {
+		m                map[MessageType]Validators
+		defaultValidator Validator
+		msg              Message
+	}
+
+	var alwaysValidMsg ValidatorFunc = func(msg Message) error { return nil }
+	tests := []struct {
+		description string
+		value       Test
+		expectedErr error
+	}{
+		// Success case
+		{
+			description: "known message type with successful Validators",
+			value: Test{
+				m: map[MessageType]Validators{
+					SimpleEventMessageType: {alwaysValidMsg},
+				},
+				msg: Message{Type: SimpleEventMessageType},
+			},
+		},
+		{
+			description: "unknown message type with provided default Validator",
+			value: Test{
+				m: map[MessageType]Validators{
+					SimpleEventMessageType: {alwaysValidMsg},
+				},
+				defaultValidator: alwaysValidMsg,
+				msg:              Message{Type: CreateMessageType},
+			},
+		},
+		// Failure case
+		{
+			description: "known message type with failing Validators",
+			value: Test{
+				m: map[MessageType]Validators{
+					SimpleEventMessageType: {alwaysInvalidMsg()},
+				},
+				msg: Message{Type: SimpleEventMessageType},
+			},
+			expectedErr: ErrInvalidMsgType,
+		},
+		{
+			description: "unknown message type without provided default Validator",
+			value: Test{
+				m: map[MessageType]Validators{
+					SimpleEventMessageType: {alwaysValidMsg},
+				},
+				msg: Message{Type: CreateMessageType},
+			},
+			expectedErr: ErrInvalidMsgType,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			msgv, err := NewMsgTypeValidator(tc.value.m, tc.value.defaultValidator)
+			assert.NotNil(msgv)
+			assert.Nil(err)
+			err = msgv.Validate(tc.value.msg)
+			if tc.expectedErr != nil {
+				assert.ErrorIs(err, tc.expectedErr)
+				return
+			}
+
+			assert.Nil(err)
+		})
+	}
+}
+
+func testNewMsgTypeValidator(t *testing.T) {
+	type Test struct {
+		m                map[MessageType]Validators
+		defaultValidator Validator
+	}
+
+	var alwaysValidMsg ValidatorFunc = func(msg Message) error { return nil }
+	tests := []struct {
+		description string
+		value       Test
+		expectedErr error
+	}{
+		// Success case
+		{
+			description: "with provided default Validator",
+			value: Test{
+				m: map[MessageType]Validators{
+					SimpleEventMessageType: {alwaysValidMsg},
+				},
+				defaultValidator: alwaysValidMsg,
+			},
+			expectedErr: nil,
+		},
+		{
+			description: "without provided default Validator",
+			value: Test{
+				m: map[MessageType]Validators{
+					SimpleEventMessageType: {alwaysValidMsg},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			description: "empty list of message type Validators",
+			value: Test{
+				m: map[MessageType]Validators{
+					SimpleEventMessageType: {},
+				},
+				defaultValidator: alwaysValidMsg,
+			},
+			expectedErr: nil,
+		},
+		// Failure case
+		{
+			description: "missing message type Validators",
+			value:       Test{},
+			expectedErr: ErrInvalidMsgTypeValidator,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			msgv, err := NewMsgTypeValidator(tc.value.m, tc.value.defaultValidator)
+			assert.NotNil(msgv)
+			if tc.expectedErr != nil {
+				assert.ErrorIs(err, tc.expectedErr)
+				return
+			}
+
+			assert.Nil(err)
+		})
+	}
+}
+
+func testAlwaysInvalidMsg(t *testing.T) {
+	assert := assert.New(t)
+	msg := Message{}
+	v := alwaysInvalidMsg()
+
+	assert.NotNil(v)
+	err := v(msg)
+
+	assert.NotNil(err)
+	assert.ErrorIs(err, ErrInvalidMsgType)
+
+}
+
+func TestHelperValidators(t *testing.T) {
+	tests := []struct {
+		name string
+		test func(*testing.T)
+	}{
+		{"alwaysInvalidMsg", testAlwaysInvalidMsg},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, tc.test)
+	}
+}
+
+func TestMsgTypeValidator(t *testing.T) {
+	tests := []struct {
+		name string
+		test func(*testing.T)
+	}{
+		{"MsgTypeValidator validate", testMsgTypeValidatorValidate},
+		{"MsgTypeValidator factory", testNewMsgTypeValidator},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, tc.test)
+	}
+}

--- a/validator_test.go
+++ b/validator_test.go
@@ -18,6 +18,7 @@
 package wrp
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,9 +27,9 @@ import (
 
 func testTypeValidatorValidate(t *testing.T) {
 	type Test struct {
-		m                map[MessageType]Validators
-		defaultValidator Validator
-		msg              Message
+		m                 map[MessageType]Validators
+		defaultValidators Validators
+		msg               Message
 	}
 
 	var alwaysValid ValidatorFunc = func(msg Message) error { return nil }
@@ -53,8 +54,8 @@ func testTypeValidatorValidate(t *testing.T) {
 				m: map[MessageType]Validators{
 					SimpleEventMessageType: {AlwaysInvalid},
 				},
-				defaultValidator: alwaysValid,
-				msg:              Message{Type: CreateMessageType},
+				defaultValidators: Validators{alwaysValid},
+				msg:               Message{Type: CreateMessageType},
 			},
 		},
 		// Failure case
@@ -64,8 +65,8 @@ func testTypeValidatorValidate(t *testing.T) {
 				m: map[MessageType]Validators{
 					SimpleEventMessageType: {AlwaysInvalid},
 				},
-				defaultValidator: alwaysValid,
-				msg:              Message{Type: SimpleEventMessageType},
+				defaultValidators: Validators{alwaysValid},
+				msg:               Message{Type: SimpleEventMessageType},
 			},
 			expectedErr: ErrInvalidMsgType,
 		},
@@ -85,7 +86,7 @@ func testTypeValidatorValidate(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
 			require := require.New(t)
-			msgv, err := NewTypeValidator(tc.value.m, tc.value.defaultValidator)
+			msgv, err := NewTypeValidator(tc.value.m, tc.value.defaultValidators...)
 			require.NotNil(msgv)
 			require.NoError(err)
 			err = msgv.Validate(tc.value.msg)
@@ -101,8 +102,8 @@ func testTypeValidatorValidate(t *testing.T) {
 
 func testNewTypeValidator(t *testing.T) {
 	type Test struct {
-		m                map[MessageType]Validators
-		defaultValidator Validator
+		m                 map[MessageType]Validators
+		defaultValidators Validators
 	}
 
 	var alwaysValid ValidatorFunc = func(msg Message) error { return nil }
@@ -118,15 +119,15 @@ func testNewTypeValidator(t *testing.T) {
 				m: map[MessageType]Validators{
 					SimpleEventMessageType: {alwaysValid},
 				},
-				defaultValidator: alwaysValid,
+				defaultValidators: Validators{alwaysValid},
 			},
 			expectedErr: nil,
 		},
 		{
 			description: "Empty map of Validators success",
 			value: Test{
-				m:                map[MessageType]Validators{},
-				defaultValidator: alwaysValid,
+				m:                 map[MessageType]Validators{},
+				defaultValidators: Validators{alwaysValid},
 			},
 			expectedErr: nil,
 		},
@@ -146,7 +147,7 @@ func testNewTypeValidator(t *testing.T) {
 				m: map[MessageType]Validators{
 					SimpleEventMessageType: {},
 				},
-				defaultValidator: alwaysValid,
+				defaultValidators: Validators{alwaysValid},
 			},
 			expectedErr: ErrInvalidTypeValidator,
 		},
@@ -156,7 +157,7 @@ func testNewTypeValidator(t *testing.T) {
 				m: map[MessageType]Validators{
 					SimpleEventMessageType: nil,
 				},
-				defaultValidator: alwaysValid,
+				defaultValidators: Validators{alwaysValid},
 			},
 			expectedErr: ErrInvalidTypeValidator,
 		},
@@ -166,7 +167,7 @@ func testNewTypeValidator(t *testing.T) {
 				m: map[MessageType]Validators{
 					SimpleEventMessageType: {nil},
 				},
-				defaultValidator: alwaysValid,
+				defaultValidators: Validators{alwaysValid},
 			},
 			expectedErr: ErrInvalidTypeValidator,
 		},
@@ -179,7 +180,7 @@ func testNewTypeValidator(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
-			msgv, err := NewTypeValidator(tc.value.m, tc.value.defaultValidator)
+			msgv, err := NewTypeValidator(tc.value.m, tc.value.defaultValidators...)
 			assert.NotNil(msgv)
 			if tc.expectedErr != nil {
 				assert.ErrorIs(err, tc.expectedErr)
@@ -225,4 +226,43 @@ func TestTypeValidator(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, tc.test)
 	}
+}
+
+func ExampleNewTypeValidator() {
+	var alwaysValid ValidatorFunc = func(msg Message) error { return nil }
+	msgv, err := NewTypeValidator(
+		// Validates known msg types
+		map[MessageType]Validators{SimpleEventMessageType: {alwaysValid}},
+		// Validates unknown msg types
+		AlwaysInvalid)
+	if err != nil {
+		return
+	}
+	err = msgv.Validate(Message{Type: SimpleEventMessageType}) // Found success
+	fmt.Println(err == nil)
+	// Output: true
+
+}
+
+func ExampleTypeValidator_Validate_found() {
+	var alwaysValid ValidatorFunc = func(msg Message) error { return nil }
+	msgv, err := NewTypeValidator(
+		// Validates known msg types
+		map[MessageType]Validators{SimpleEventMessageType: {alwaysValid}},
+		// Validates unknown msg types
+		AlwaysInvalid)
+	err = msgv.Validate(Message{Type: SimpleEventMessageType}) // Found success
+	fmt.Println(err == nil)
+	// Output: true
+}
+func ExampleTypeValidator_Validate_notFound() {
+	var alwaysValid ValidatorFunc = func(msg Message) error { return nil }
+	msgv, err := NewTypeValidator(
+		// Validates known msg types
+		map[MessageType]Validators{SimpleEventMessageType: {alwaysValid}},
+		// Validates unknown msg types
+		AlwaysInvalid)
+	err = msgv.Validate(Message{Type: CreateMessageType}) // Not Found error
+	fmt.Println(err == nil)
+	// Output: false
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -259,14 +259,14 @@ func testTypeValidatorFactory(t *testing.T) {
 			msgv, err := NewTypeValidator(tc.m, tc.defaultValidators...)
 			if tc.expectedErr != nil {
 				assert.ErrorIs(err, tc.expectedErr)
-				assert.NotNil(msgv)
-				assert.NotZero(msgv)
+				// Zero asserts that msgv is the zero value for its type and not nil.
+				assert.Zero(msgv)
 				return
 			}
 
 			assert.NoError(err)
-			// Zero asserts that msgv is the zero value for its type and not nil.
-			assert.Zero(msgv)
+			assert.NotNil(msgv)
+			assert.NotZero(msgv)
 		})
 	}
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -123,7 +123,7 @@ func testNewTypeValidator(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			description: "Empty map of Validator success",
+			description: "Empty map of Validators success",
 			value: Test{
 				m:                map[MessageType]Validators{},
 				defaultValidator: alwaysValid,

--- a/validator_test.go
+++ b/validator_test.go
@@ -121,11 +121,11 @@ func ExampleTypeValidator_Validate() {
 
 func testTypeValidatorValidate(t *testing.T) {
 	tests := []struct {
-		description       string
-		m                 map[MessageType]Validator
-		defaultValidators []Validator
-		msg               Message
-		expectedErr       error
+		description      string
+		m                map[MessageType]Validator
+		defaultValidator Validator
+		msg              Message
+		expectedErr      error
 	}{
 		// Success case
 		{
@@ -140,24 +140,24 @@ func testTypeValidatorValidate(t *testing.T) {
 			m: map[MessageType]Validator{
 				SimpleEventMessageType: AlwaysInvalid,
 			},
-			defaultValidators: []Validator{AlwaysValid},
-			msg:               Message{Type: CreateMessageType},
+			defaultValidator: AlwaysValid,
+			msg:              Message{Type: CreateMessageType},
 		},
 		{
 			description: "Unfound success, nil list of default Validators",
 			m: map[MessageType]Validator{
 				SimpleEventMessageType: AlwaysInvalid,
 			},
-			defaultValidators: []Validator{nil},
-			msg:               Message{Type: CreateMessageType},
+			defaultValidator: Validators{nil},
+			msg:              Message{Type: CreateMessageType},
 		},
 		{
 			description: "Unfound success, empty map of default Validators",
 			m: map[MessageType]Validator{
 				SimpleEventMessageType: AlwaysInvalid,
 			},
-			defaultValidators: []Validator{},
-			msg:               Message{Type: CreateMessageType},
+			defaultValidator: Validators{},
+			msg:              Message{Type: CreateMessageType},
 		},
 		// Failure case
 		{
@@ -165,9 +165,9 @@ func testTypeValidatorValidate(t *testing.T) {
 			m: map[MessageType]Validator{
 				SimpleEventMessageType: AlwaysInvalid,
 			},
-			defaultValidators: []Validator{AlwaysValid},
-			msg:               Message{Type: SimpleEventMessageType},
-			expectedErr:       ErrInvalidMsgType,
+			defaultValidator: AlwaysValid,
+			msg:              Message{Type: SimpleEventMessageType},
+			expectedErr:      ErrInvalidMsgType,
 		},
 		{
 			description: "Found error, nil Validator",
@@ -190,9 +190,9 @@ func testTypeValidatorValidate(t *testing.T) {
 			m: map[MessageType]Validator{
 				SimpleEventMessageType: AlwaysInvalid,
 			},
-			defaultValidators: nil,
-			msg:               Message{Type: CreateMessageType},
-			expectedErr:       ErrInvalidMsgType,
+			defaultValidator: nil,
+			msg:              Message{Type: CreateMessageType},
+			expectedErr:      ErrInvalidMsgType,
 		},
 		{
 			description: "Unfound error, empty map of Validators",
@@ -206,7 +206,7 @@ func testTypeValidatorValidate(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
 			require := require.New(t)
-			msgv, err := NewTypeValidator(tc.m, tc.defaultValidators...)
+			msgv, err := NewTypeValidator(tc.m, tc.defaultValidator)
 			require.NoError(err)
 			require.NotNil(msgv)
 			assert.NotZero(msgv)
@@ -223,10 +223,10 @@ func testTypeValidatorValidate(t *testing.T) {
 
 func testTypeValidatorFactory(t *testing.T) {
 	tests := []struct {
-		description       string
-		m                 map[MessageType]Validator
-		defaultValidators []Validator
-		expectedErr       error
+		description      string
+		m                map[MessageType]Validator
+		defaultValidator Validator
+		expectedErr      error
 	}{
 		// Success case
 		{
@@ -234,8 +234,8 @@ func testTypeValidatorFactory(t *testing.T) {
 			m: map[MessageType]Validator{
 				SimpleEventMessageType: AlwaysValid,
 			},
-			defaultValidators: []Validator{AlwaysValid},
-			expectedErr:       nil,
+			defaultValidator: AlwaysValid,
+			expectedErr:      nil,
 		},
 		{
 			description: "Omit default Validators success",
@@ -246,17 +246,17 @@ func testTypeValidatorFactory(t *testing.T) {
 		},
 		// Failure case
 		{
-			description:       "Nil map of Validators error",
-			m:                 nil,
-			defaultValidators: []Validator{AlwaysValid},
-			expectedErr:       ErrInvalidValidator,
+			description:      "Nil map of Validators error",
+			m:                nil,
+			defaultValidator: AlwaysValid,
+			expectedErr:      ErrInvalidValidator,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
-			msgv, err := NewTypeValidator(tc.m, tc.defaultValidators...)
+			msgv, err := NewTypeValidator(tc.m, tc.defaultValidator)
 			if tc.expectedErr != nil {
 				assert.ErrorIs(err, tc.expectedErr)
 				// Zero asserts that msgv is the zero value for its type and not nil.

--- a/validator_test.go
+++ b/validator_test.go
@@ -202,27 +202,27 @@ func testAlwaysInvalid(t *testing.T) {
 
 func TestHelperValidators(t *testing.T) {
 	tests := []struct {
-		name string
-		test func(*testing.T)
+		description string
+		test        func(*testing.T)
 	}{
 		{"AlwaysInvalid", testAlwaysInvalid},
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, tc.test)
+		t.Run(tc.description, tc.test)
 	}
 }
 
 func TestTypeValidator(t *testing.T) {
 	tests := []struct {
-		name string
-		test func(*testing.T)
+		description string
+		test        func(*testing.T)
 	}{
 		{"TypeValidator validate", testTypeValidatorValidate},
 		{"TypeValidator factory", testNewTypeValidator},
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, tc.test)
+		t.Run(tc.description, tc.test)
 	}
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -337,7 +337,7 @@ func testAlwaysValid(t *testing.T) {
 		{
 			description: "Bad message type success",
 			msg: Message{
-				Type:        lastMessageType,
+				Type:        lastMessageType + 1,
 				Source:      "external.com",
 				Destination: "MAC:11:22:33:44:55:66",
 			},
@@ -419,7 +419,7 @@ func testAlwaysInvalid(t *testing.T) {
 		{
 			description: "Bad message type error",
 			msg: Message{
-				Type:        lastMessageType,
+				Type:        lastMessageType + 1,
 				Source:      "external.com",
 				Destination: "MAC:11:22:33:44:55:66",
 			},

--- a/validator_test.go
+++ b/validator_test.go
@@ -140,7 +140,7 @@ func testNewTypeValidator(t *testing.T) {
 		},
 		// Failure case
 		{
-			description: "Nil list of default Validators error ",
+			description: "Nil list of default Validators error",
 			value: Test{
 				m: map[MessageType]Validator{
 					SimpleEventMessageType: AlwaysValid,

--- a/validator_test.go
+++ b/validator_test.go
@@ -57,14 +57,6 @@ func testTypeValidatorValidate(t *testing.T) {
 				msg:              Message{Type: CreateMessageType},
 			},
 		},
-		{
-			description: "Never found success",
-			value: Test{
-				m:                map[MessageType]Validators{},
-				defaultValidator: alwaysValid,
-				msg:              Message{Type: CreateMessageType},
-			},
-		},
 		// Failure case
 		{
 			description: "Found error",

--- a/validator_test.go
+++ b/validator_test.go
@@ -204,6 +204,13 @@ func testNewTypeValidator(t *testing.T) {
 	}
 }
 
+func testAlwaysValid(t *testing.T) {
+	assert := assert.New(t)
+	msg := Message{}
+	err := AlwaysValid(msg)
+	assert.NoError(err)
+}
+
 func testAlwaysInvalid(t *testing.T) {
 	assert := assert.New(t)
 	msg := Message{}
@@ -217,6 +224,7 @@ func TestHelperValidators(t *testing.T) {
 		test        func(*testing.T)
 	}{
 		{"AlwaysInvalid", testAlwaysInvalid},
+		{"AlwaysValid", testAlwaysValid},
 	}
 
 	for _, tc := range tests {

--- a/validator_test.go
+++ b/validator_test.go
@@ -123,7 +123,7 @@ func testNewTypeValidator(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			description: "Omit map of Validator success",
+			description: "Empty map of Validator success",
 			value: Test{
 				m:                map[MessageType]Validators{},
 				defaultValidator: alwaysValid,

--- a/validator_test.go
+++ b/validator_test.go
@@ -151,6 +151,26 @@ func testNewTypeValidator(t *testing.T) {
 			expectedErr: ErrInvalidTypeValidator,
 		},
 		{
+			description: "Nil Validators error",
+			value: Test{
+				m: map[MessageType]Validators{
+					SimpleEventMessageType: nil,
+				},
+				defaultValidator: alwaysValid,
+			},
+			expectedErr: ErrInvalidTypeValidator,
+		},
+		{
+			description: "Nil list of Validators error",
+			value: Test{
+				m: map[MessageType]Validators{
+					SimpleEventMessageType: {nil},
+				},
+				defaultValidator: alwaysValid,
+			},
+			expectedErr: ErrInvalidTypeValidator,
+		},
+		{
 			description: "Empty map of Validators error",
 			value:       Test{},
 			expectedErr: ErrInvalidTypeValidator,

--- a/validator_test.go
+++ b/validator_test.go
@@ -116,7 +116,7 @@ func testTypeValidatorValidate(t *testing.T) {
 			msgv, err := NewTypeValidator(tc.m, tc.defaultValidators...)
 			require.NoError(err)
 			require.NotNil(msgv)
-			require.False(msgv.IsBad())
+			assert.NotZero(msgv)
 			err = msgv.Validate(tc.msg)
 			if tc.expectedErr != nil {
 				assert.ErrorIs(err, tc.expectedErr)
@@ -164,16 +164,16 @@ func testTypeValidatorFactory(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
 			msgv, err := NewTypeValidator(tc.m, tc.defaultValidators...)
-			assert.NotNil(msgv)
 			if tc.expectedErr != nil {
 				assert.ErrorIs(err, tc.expectedErr)
-				assert.ErrorIs(msgv.Validate(Message{}), ErrInvalidTypeValidator)
-				assert.True(msgv.IsBad())
+				assert.NotNil(msgv)
+				assert.NotZero(msgv)
 				return
 			}
 
 			assert.NoError(err)
-			assert.False(msgv.IsBad())
+			// Zero asserts that msgv is the zero value for its type and not nil.
+			assert.Zero(msgv)
 		})
 	}
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -61,7 +61,7 @@ func testMsgTypeValidatorValidate(t *testing.T) {
 			description: "known message type with failing Validators",
 			value: Test{
 				m: map[MessageType]Validators{
-					SimpleEventMessageType: {alwaysInvalidMsg},
+					SimpleEventMessageType: {AlwaysInvalidMsg},
 				},
 				msg: Message{Type: SimpleEventMessageType},
 			},
@@ -162,7 +162,7 @@ func testNewMsgTypeValidator(t *testing.T) {
 func testAlwaysInvalidMsg(t *testing.T) {
 	assert := assert.New(t)
 	msg := Message{}
-	err := alwaysInvalidMsg(msg)
+	err := AlwaysInvalidMsg(msg)
 
 	assert.NotNil(err)
 	assert.ErrorIs(err, ErrInvalidMsgType)
@@ -174,7 +174,7 @@ func TestHelperValidators(t *testing.T) {
 		name string
 		test func(*testing.T)
 	}{
-		{"alwaysInvalidMsg", testAlwaysInvalidMsg},
+		{"AlwaysInvalidMsg", testAlwaysInvalidMsg},
 	}
 
 	for _, tc := range tests {

--- a/validator_test.go
+++ b/validator_test.go
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+
 package wrp
 
 import (


### PR DESCRIPTION
## Overview

related to #25, #78, xmidt-org/scytale#88, xmidt-org/talaria#153 s.t. we want a validation mechanism that is configurable by clients & verifies the spec.

### tl;dr
This pr introduces the initial validation framework, where clients supply validators (satisfying the `Validator interface`) to `NewMsgTypeValidator` and then used to verify the spec.

<details>
<summary> Explanation</summary>

Clients supply validators satisfying:
```go
// Validator is a WRP validator that allows access to the Validate function.
type Validator interface {
	Validate(m Message) error
}
```

and listing which validators are used on known and unknown msg types (where unknown msg types are handled by `defaultValidator`):
```go
var alwaysValid ValidatorFunc = func(msg Message) error { return nil }
msgv, err := NewTypeValidator(
	// Validates found msg types
	map[MessageType]Validators{SimpleEventMessageType: {alwaysValid}},
	// Validates unfound msg types
	AlwaysInvalid)
err = msgv.Validate(Message{Type: SimpleEventMessageType}) // Found success
err == nil // True
err = msgv.Validate(Message{Type: CreateMessageType}) // Unfound error
err == nil // False
```

if a default validator is not provided, all unknown msg type will **fail** by default
```go
msgv, err := NewTypeValidator( // Omitted defaultValidator
	map[MessageType]Validators{SimpleEventMessageType: {alwaysValid}})
err = msgv.Validate(Message{Type: CreateMessageType}) // Unfound error
err == nil // False 
```
</details>

<details>
<summary>Type of Change(s)</summary>

- Non-breaking Enhancement
- All new and existing tests passed.

</details>