### PR TITLE
Add spec validators for the WRP messages (BAD BRANCH)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ report.json
 
 # Images
 *.png
+
+# VSCode
+*.code-workspace
+.vscode/*

--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,5 @@ require (
 	github.com/ugorji/go/codec v1.2.6
 	github.com/xmidt-org/httpaux v0.3.0
 	github.com/xmidt-org/webpa-common v1.3.2
+	go.uber.org/multierr v1.8.0
 )

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-kit/kit v0.8.0
 	github.com/go-logfmt/logfmt v0.3.0 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/google/uuid v1.3.0
 	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/ugorji/go/codec v1.2.6

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/go-logfmt/logfmt v0.3.0 h1:8HUsc87TaSWLKwrnumgC8/YconD2fJQsRJAsWaPg2i
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj2vyii2bbUNDw3kt9VxK2EY=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,10 @@ github.com/xmidt-org/httpaux v0.3.0 h1:JdV4QceiE8EMA1Qf5rnJzHdkIPzQV12ddARHLU8hr
 github.com/xmidt-org/httpaux v0.3.0/go.mod h1:mviIlg5fHGb3lAv3l0sbiwVG/q9rqvXaudEYxVrzXdE=
 github.com/xmidt-org/webpa-common v1.3.2 h1:dE1Fi+XVnkt3tMGMjH7/hN/UGcaQ/ukKriXuMDyCWnM=
 github.com/xmidt-org/webpa-common v1.3.2/go.mod h1:oCpKzOC+9h2vYHVzAU/06tDTQuBN4RZz+rhgIXptpOI=
+go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
+go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/multierr v1.8.0 h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
+go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/header_wrp.go
+++ b/header_wrp.go
@@ -30,8 +30,6 @@ const (
 	SourceHeader          = "X-Midt-Source"
 )
 
-// var ErrInvalidMsgType = errors.New("Invalid Message Type")
-
 // Map string to MessageType int
 /*
 func StringToMessageType(str string) MessageType {

--- a/header_wrp.go
+++ b/header_wrp.go
@@ -17,10 +17,6 @@
 
 package wrp
 
-import (
-	"errors"
-)
-
 // Constant HTTP header strings representing WRP fields
 const (
 	MsgTypeHeader         = "X-Midt-Msg-Type"
@@ -34,7 +30,7 @@ const (
 	SourceHeader          = "X-Midt-Source"
 )
 
-var ErrInvalidMsgType = errors.New("Invalid Message Type")
+// var ErrInvalidMsgType = errors.New("Invalid Message Type")
 
 // Map string to MessageType int
 /*

--- a/spec_validator.go
+++ b/spec_validator.go
@@ -137,6 +137,10 @@ func validateLocator(l string) error {
 		if _, err := uuid.Parse(idPart); err != nil {
 			return err
 		}
+	case serialPrefix, eventPrefix, dnsPrefix:
+		if len(idPart) == 0 {
+			return fmt.Errorf("invalid %v empty authority (ID)", serialPrefix)
+		}
 	}
 
 	return nil

--- a/spec_validator.go
+++ b/spec_validator.go
@@ -49,7 +49,7 @@ var LocatorPattern = regexp.MustCompile(
 )
 
 // SpecValidators is a WRP validator that ensures messages are valid based on
-// each spec validator in the list.
+// each spec validator in the list. Only validates the opinionated portions of the spec.
 var SpecValidators = Validators{UTF8Validator, MessageTypeValidator, SourceValidator, DestinationValidator}
 
 // UTF8Validator is a WRP validator that takes messages and validates that it contains UTF-8 strings.

--- a/spec_validator_test.go
+++ b/spec_validator_test.go
@@ -61,7 +61,7 @@ func testUTF8Validator(t *testing.T) {
 		{
 			description: "Not UTF8 error",
 			value:       *msg,
-			expectedErr: []error{ErrorInvalidMessageEncoding, ErrNotUTF8},
+			expectedErr: []error{ErrorInvalidMessageEncoding},
 		},
 	}
 
@@ -189,7 +189,7 @@ func testSourceValidator(t *testing.T) {
 	tests := []struct {
 		description string
 		value       Message
-		expectedErr []error
+		expectedErr error
 	}{
 		// Success case
 		{
@@ -201,7 +201,7 @@ func testSourceValidator(t *testing.T) {
 		{
 			description: "Source error",
 			value:       Message{Source: "invalid:a-BB-44-55"},
-			expectedErr: []error{ErrorInvalidSource, ErrorInvalidLocator},
+			expectedErr: ErrorInvalidSource,
 		},
 	}
 
@@ -210,9 +210,7 @@ func testSourceValidator(t *testing.T) {
 			assert := assert.New(t)
 			err := SourceValidator(tc.value)
 			if tc.expectedErr != nil {
-				for _, e := range tc.expectedErr {
-					assert.ErrorIs(err, e)
-				}
+				assert.ErrorIs(err, tc.expectedErr)
 				return
 			}
 
@@ -225,7 +223,7 @@ func testDestinationValidator(t *testing.T) {
 	tests := []struct {
 		description string
 		value       Message
-		expectedErr []error
+		expectedErr error
 	}{
 		// Success case
 		{
@@ -237,7 +235,7 @@ func testDestinationValidator(t *testing.T) {
 		{
 			description: "Destination error",
 			value:       Message{Destination: "invalid:a-BB-44-55"},
-			expectedErr: []error{ErrorInvalidDestination, ErrorInvalidLocator},
+			expectedErr: ErrorInvalidDestination,
 		},
 	}
 
@@ -246,9 +244,7 @@ func testDestinationValidator(t *testing.T) {
 			assert := assert.New(t)
 			err := DestinationValidator(tc.value)
 			if tc.expectedErr != nil {
-				for _, e := range tc.expectedErr {
-					assert.ErrorIs(err, e)
-				}
+				assert.ErrorIs(err, tc.expectedErr)
 				return
 			}
 
@@ -261,120 +257,120 @@ func testValidateLocator(t *testing.T) {
 	tests := []struct {
 		description string
 		value       string
-		expectedErr error
+		shouldErr   bool
 	}{
 		// mac success case
 		{
 			description: "Mac ID ':' delimiter success",
 			value:       "MAC:11:22:33:44:55:66",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		{
 			description: "Mac ID no delimiter success",
 			value:       "MAC:11aaBB445566",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		{
 			description: "Mac ID '-' delimiter success",
 			value:       "mac:11-aa-BB-44-55-66",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		{
 			description: "Mac ID ',' delimiter success",
 			value:       "mac:11,aa,BB,44,55,66",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		{
 			description: "Mac with service success",
 			value:       "mac:11,aa,BB,44,55,66/parodus/tag/test0",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		// Mac failure case
 		{
 			description: "Invalid mac ID character error",
 			value:       "MAC:invalid45566",
-			expectedErr: ErrorInvalidLocator,
+			shouldErr:   true,
 		},
 		{
 			description: "Invalid mac ID length error",
 			value:       "mac:11-aa-BB-44-55",
-			expectedErr: ErrorInvalidLocator,
+			shouldErr:   true,
 		},
 		// Serial success case
 		{
 			description: "Serial ID success",
 			value:       "serial:anything Goes!",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		// UUID success case
 		{
 			description: "UUID RFC4122 variant ID success", // The variant specified in RFC4122
 			value:       "uuid:f47ac10b-58cc-0372-8567-0e02b2c3d479",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		{
 			description: "UUID RFC4122 variant with Microsoft encoding ID success", // The variant specified in RFC4122
 			value:       "uuid:{f47ac10b-58cc-0372-8567-0e02b2c3d479}",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		{
 			description: "UUID Reserved variant ID #1 success", // Reserved, NCS backward compatibility.
 			value:       "UUID:urn:uuid:f47ac10b-58cc-4372-0567-0e02b2c3d479",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		{
 			description: "UUID Reserved variant ID #2 success", // Reserved, NCS backward compatibility.
 			value:       "UUID:URN:UUID:f47ac10b-58cc-4372-0567-0e02b2c3d479",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		{
 			description: "UUID Reserved variant ID #3 success", // Reserved, NCS backward compatibility.
 			value:       "UUID:f47ac10b-58cc-4372-0567-0e02b2c3d479",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		{
 			description: "UUID Microsoft variant ID success", // Reserved, Microsoft Corporation backward compatibility.
 			value:       "uuid:f47ac10b-58cc-4372-c567-0e02b2c3d479",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		{
 			description: "UUID Future variant ID success", // Reserved for future definition.
 			value:       "uuid:f47ac10b-58cc-4372-e567-0e02b2c3d479",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		// UUID failure case
 		{
 			description: "Invalid UUID ID #1 error",
 			value:       "uuid:invalid45566",
-			expectedErr: ErrorInvalidLocator,
+			shouldErr:   true,
 		},
 		{
 			description: "Invalid UUID ID #2 error",
 			value:       "uuid:URN:UUID:invalid45566",
-			expectedErr: ErrorInvalidLocator,
+			shouldErr:   true,
 		},
 		{
 			description: "Invalid UUID ID #3 error",
 			value:       "uuid:{invalid45566}",
-			expectedErr: ErrorInvalidLocator,
+			shouldErr:   true,
 		},
 		// Event success case
 		{
 			description: "Event ID success",
 			value:       "event:anything Goes!",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		// DNS success case
 		{
 			description: "DNS ID success",
 			value:       "dns:anything Goes!",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		// Scheme failure case
 		{
 			description: "Invalid scheme error",
 			value:       "invalid:a-BB-44-55",
-			expectedErr: ErrorInvalidLocator,
+			shouldErr:   true,
 		},
 	}
 
@@ -382,8 +378,8 @@ func testValidateLocator(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
 			err := validateLocator(tc.value)
-			if tc.expectedErr != nil {
-				assert.ErrorIs(err, tc.expectedErr)
+			if tc.shouldErr {
+				assert.Error(err)
 				return
 			}
 
@@ -433,14 +429,14 @@ func TestSpecValidators(t *testing.T) {
 				Source:      "invalid:a-BB-44-55",
 				Destination: "invalid:a-BB-44-55",
 			},
-			expectedErr: []error{ErrorInvalidMessageType, ErrorInvalidSource, ErrorInvalidLocator, ErrorInvalidDestination},
+			expectedErr: []error{ErrorInvalidMessageType, ErrorInvalidSource, ErrorInvalidDestination},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
-			err := SpecValidators.Validate(tc.value)
+			err := SpecValidators().Validate(tc.value)
 			if tc.expectedErr != nil {
 				for _, e := range tc.expectedErr {
 					assert.ErrorIs(err, e)
@@ -458,7 +454,7 @@ func ExampleTypeValidator_Validate_specValidators() {
 		// Validates found msg types
 		map[MessageType]Validator{
 			// Validates opinionated portions of the spec
-			SimpleEventMessageType: SpecValidators,
+			SimpleEventMessageType: SpecValidators(),
 			// Only validates Source and nothing else
 			SimpleRequestResponseMessageType: SourceValidator,
 		},

--- a/spec_validator_test.go
+++ b/spec_validator_test.go
@@ -1,0 +1,443 @@
+/**
+ *  Copyright (c) 2022  Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wrp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testUTF8Validator(t *testing.T) {
+	/*
+		"\x85"  - 5 name value pairs
+			"\xa8""msg_type"         : "\x03" // 3
+			"\xa4""dest"             : "\xac""\xed\xbf\xbft-address"
+			"\xa7""payload"          : "\xc4""\x03" - len 3
+											 "123"
+			"\xa6""source"           : "\xae""source-address"
+			"\xb0""transaction_uuid" : "\xd9\x24""c07ee5e1-70be-444c-a156-097c767ad8aa"
+	*/
+	invalid := []byte{
+		0x85,
+		0xa8, 'm', 's', 'g', '_', 't', 'y', 'p', 'e', 0x03,
+		0xa4, 'd', 'e', 's', 't', 0xac /* \xed\xbf\xbf is invalid */, 0xed, 0xbf, 0xbf, 't', '-', 'a', 'd', 'd', 'r', 'e', 's', 's',
+		0xa7, 'p', 'a', 'y', 'l', 'o', 'a', 'd', 0xc4, 0x03, '1', '2', '3',
+		0xa6, 's', 'o', 'u', 'r', 'c', 'e', 0xae, 's', 'o', 'u', 'r', 'c', 'e', '-', 'a', 'd', 'd', 'r', 'e', 's', 's',
+		0xb0, 't', 'r', 'a', 'n', 's', 'a', 'c', 't', 'i', 'o', 'n', '_', 'u', 'u', 'i', 'd', 0xd9, 0x24, 'c', '0', '7', 'e', 'e', '5', 'e', '1', '-', '7', '0', 'b', 'e', '-', '4', '4', '4', 'c', '-', 'a', '1', '5', '6', '-', '0', '9', '7', 'c', '7', '6', '7', 'a', 'd', '8', 'a', 'a',
+	}
+	decoder := NewDecoderBytes(invalid, Msgpack)
+	msg := new(Message)
+	err := decoder.Decode(msg)
+	require.NoError(t, err)
+	tests := []struct {
+		description string
+		value       Message
+		expectedErr []error
+	}{
+		// Success case
+		{
+			description: "UTF8 success",
+			value:       Message{Source: "MAC:11:22:33:44:55:66"},
+			expectedErr: nil,
+		},
+		{
+			description: "Not UTF8 error",
+			value:       *msg,
+			expectedErr: []error{ErrorInvalidMessageEncoding, ErrNotUTF8},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			err := UTF8Validator(tc.value)
+			if tc.expectedErr != nil {
+				for _, e := range tc.expectedErr {
+					assert.ErrorIs(err, e)
+				}
+				return
+			}
+
+			assert.NoError(err)
+		})
+	}
+}
+
+func testMessageTypeValidator(t *testing.T) {
+	tests := []struct {
+		description string
+		value       Message
+		expectedErr error
+	}{
+		// Success case
+		{
+			description: "AuthorizationMessageType success",
+			value:       Message{Type: AuthorizationMessageType},
+			expectedErr: nil,
+		},
+		{
+			description: "SimpleRequestResponseMessageType success",
+			value:       Message{Type: SimpleRequestResponseMessageType},
+			expectedErr: nil,
+		},
+		{
+			description: "SimpleEventMessageType success",
+			value:       Message{Type: SimpleEventMessageType},
+			expectedErr: nil,
+		},
+		{
+			description: "CreateMessageType success",
+			value:       Message{Type: CreateMessageType},
+			expectedErr: nil,
+		},
+		{
+			description: "RetrieveMessageType success",
+			value:       Message{Type: RetrieveMessageType},
+			expectedErr: nil,
+		},
+		{
+			description: "UpdateMessageType success",
+			value:       Message{Type: UpdateMessageType},
+			expectedErr: nil,
+		},
+		{
+			description: "DeleteMessageType success",
+			value:       Message{Type: DeleteMessageType},
+			expectedErr: nil,
+		},
+		{
+			description: "ServiceRegistrationMessageType success",
+			value:       Message{Type: ServiceRegistrationMessageType},
+			expectedErr: nil,
+		},
+		{
+			description: "ServiceAliveMessageType success",
+			value:       Message{Type: ServiceAliveMessageType},
+			expectedErr: nil,
+		},
+		{
+			description: "UnknownMessageType success",
+			value:       Message{Type: UnknownMessageType},
+			expectedErr: nil,
+		},
+		// Failure case
+		{
+			description: "Invalid0MessageType error",
+			value:       Message{Type: Invalid0MessageType},
+			expectedErr: ErrorInvalidMessageType,
+		},
+		{
+			description: "Invalid0MessageType error",
+			value:       Message{Type: Invalid0MessageType},
+			expectedErr: ErrorInvalidMessageType,
+		},
+		{
+			description: "Invalid1MessageType error",
+			value:       Message{Type: Invalid1MessageType},
+			expectedErr: ErrorInvalidMessageType,
+		},
+		{
+			description: "lastMessageType error",
+			value:       Message{Type: lastMessageType},
+			expectedErr: ErrorInvalidMessageType,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			err := MessageTypeValidator(tc.value)
+			if tc.expectedErr != nil {
+				assert.ErrorIs(err, tc.expectedErr)
+				return
+			}
+
+			assert.NoError(err)
+		})
+	}
+}
+
+func testSourceValidator(t *testing.T) {
+	tests := []struct {
+		description string
+		value       Message
+		expectedErr []error
+	}{
+		// Success case
+		{
+			description: "Source success",
+			value:       Message{Source: "MAC:11:22:33:44:55:66"},
+			expectedErr: nil,
+		},
+		// Failures
+		{
+			description: "Source error",
+			value:       Message{Source: "invalid:a-BB-44-55"},
+			expectedErr: []error{ErrorInvalidSource, ErrorInvalidLocator},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			err := SourceValidator(tc.value)
+			if tc.expectedErr != nil {
+				for _, e := range tc.expectedErr {
+					assert.ErrorIs(err, e)
+				}
+				return
+			}
+
+			assert.NoError(err)
+		})
+	}
+}
+
+func testDestinationValidator(t *testing.T) {
+	tests := []struct {
+		description string
+		value       Message
+		expectedErr []error
+	}{
+		// Success case
+		{
+			description: "Destination success",
+			value:       Message{Destination: "MAC:11:22:33:44:55:66"},
+			expectedErr: nil,
+		},
+		// Failures
+		{
+			description: "Destination error",
+			value:       Message{Destination: "invalid:a-BB-44-55"},
+			expectedErr: []error{ErrorInvalidDestination, ErrorInvalidLocator},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			err := DestinationValidator(tc.value)
+			if tc.expectedErr != nil {
+				for _, e := range tc.expectedErr {
+					assert.ErrorIs(err, e)
+				}
+				return
+			}
+
+			assert.NoError(err)
+		})
+	}
+}
+
+func testValidateLocator(t *testing.T) {
+	tests := []struct {
+		description string
+		value       string
+		expectedErr error
+	}{
+		// mac success case
+		{
+			description: "Mac ID ':' delimiter success",
+			value:       "MAC:11:22:33:44:55:66",
+			expectedErr: nil,
+		},
+		{
+			description: "Mac ID no delimiter success",
+			value:       "MAC:11aaBB445566",
+			expectedErr: nil,
+		},
+		{
+			description: "Mac ID '-' delimiter success",
+			value:       "mac:11-aa-BB-44-55-66",
+			expectedErr: nil,
+		},
+		{
+			description: "Mac ID ',' delimiter success",
+			value:       "mac:11,aa,BB,44,55,66",
+			expectedErr: nil,
+		},
+		{
+			description: "Mac with service success",
+			value:       "mac:11,aa,BB,44,55,66/parodus/tag/test0",
+			expectedErr: nil,
+		},
+		// Mac failure case
+		{
+			description: "Invalid mac ID character error",
+			value:       "MAC:invalid45566",
+			expectedErr: ErrorInvalidLocator,
+		},
+		{
+			description: "Invalid mac ID length error",
+			value:       "mac:11-aa-BB-44-55",
+			expectedErr: ErrorInvalidLocator,
+		},
+		// Serial success case
+		{
+			description: "Serial ID success",
+			value:       "serial:anything Goes!",
+			expectedErr: nil,
+		},
+		// UUID success case
+		{
+			description: "UUID RFC4122 variant ID success", // The variant specified in RFC4122
+			value:       "uuid:f47ac10b-58cc-0372-8567-0e02b2c3d479",
+			expectedErr: nil,
+		},
+		{
+			description: "UUID RFC4122 variant with Microsoft encoding ID success", // The variant specified in RFC4122
+			value:       "uuid:{f47ac10b-58cc-0372-8567-0e02b2c3d479}",
+			expectedErr: nil,
+		},
+		{
+			description: "UUID Reserved variant ID #1 success", // Reserved, NCS backward compatibility.
+			value:       "UUID:urn:uuid:f47ac10b-58cc-4372-0567-0e02b2c3d479",
+			expectedErr: nil,
+		},
+		{
+			description: "UUID Reserved variant ID #2 success", // Reserved, NCS backward compatibility.
+			value:       "UUID:URN:UUID:f47ac10b-58cc-4372-0567-0e02b2c3d479",
+			expectedErr: nil,
+		},
+		{
+			description: "UUID Reserved variant ID #3 success", // Reserved, NCS backward compatibility.
+			value:       "UUID:f47ac10b-58cc-4372-0567-0e02b2c3d479",
+			expectedErr: nil,
+		},
+		{
+			description: "UUID Microsoft variant ID success", // Reserved, Microsoft Corporation backward compatibility.
+			value:       "uuid:f47ac10b-58cc-4372-c567-0e02b2c3d479",
+			expectedErr: nil,
+		},
+		{
+			description: "UUID Future variant ID success", // Reserved for future definition.
+			value:       "uuid:f47ac10b-58cc-4372-e567-0e02b2c3d479",
+			expectedErr: nil,
+		},
+		// UUID failure case
+		{
+			description: "Invalid UUID ID #1 error",
+			value:       "uuid:invalid45566",
+			expectedErr: ErrorInvalidLocator,
+		},
+		{
+			description: "Invalid UUID ID #2 error",
+			value:       "uuid:URN:UUID:invalid45566",
+			expectedErr: ErrorInvalidLocator,
+		},
+		{
+			description: "Invalid UUID ID #3 error",
+			value:       "uuid:{invalid45566}",
+			expectedErr: ErrorInvalidLocator,
+		},
+		// Event success case
+		{
+			description: "Event ID success",
+			value:       "event:anything Goes!",
+			expectedErr: nil,
+		},
+		// DNS success case
+		{
+			description: "DNS ID success",
+			value:       "dns:anything Goes!",
+			expectedErr: nil,
+		},
+		// Scheme failure case
+		{
+			description: "Invalid scheme error",
+			value:       "invalid:a-BB-44-55",
+			expectedErr: ErrorInvalidLocator,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			err := validateLocator(tc.value)
+			if tc.expectedErr != nil {
+				assert.ErrorIs(err, tc.expectedErr)
+				return
+			}
+
+			assert.NoError(err)
+		})
+	}
+}
+
+func TestSpecHelperValidators(t *testing.T) {
+	tests := []struct {
+		description string
+		test        func(*testing.T)
+	}{
+		{"UTF8Validator", testUTF8Validator},
+		{"MessageTypeValidator", testMessageTypeValidator},
+		{"SourceValidator", testSourceValidator},
+		{"DestinationValidator", testDestinationValidator},
+		{"validateLocator", testValidateLocator},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, tc.test)
+	}
+}
+
+func TestSpecValidators(t *testing.T) {
+	tests := []struct {
+		description string
+		value       Message
+		expectedErr []error
+	}{
+		// Success case
+		{
+			description: "Valid specs success",
+			value: Message{
+				Type:        SimpleEventMessageType,
+				Source:      "MAC:11:22:33:44:55:66",
+				Destination: "MAC:11:22:33:44:55:66",
+			},
+			expectedErr: nil,
+		},
+		// Failure cases
+		{
+			description: "Invaild specs error",
+			value: Message{
+				Type:        Invalid0MessageType,
+				Source:      "invalid:a-BB-44-55",
+				Destination: "invalid:a-BB-44-55",
+			},
+			expectedErr: []error{ErrorInvalidMessageType, ErrorInvalidSource, ErrorInvalidLocator, ErrorInvalidDestination},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			err := SpecValidators.Validate(tc.value)
+			if tc.expectedErr != nil {
+				for _, e := range tc.expectedErr {
+					assert.ErrorIs(err, e)
+				}
+				return
+			}
+
+			assert.NoError(err)
+		})
+	}
+}

--- a/spec_validator_test.go
+++ b/spec_validator_test.go
@@ -457,6 +457,7 @@ func ExampleTypeValidator_Validate_specValidators() {
 	msgv, err := NewTypeValidator(
 		// Validates found msg types
 		map[MessageType]Validator{
+			// Validates opinionated portions of the spec
 			SimpleEventMessageType: SpecValidators,
 			// Only validates Source and nothing else
 			SimpleRequestResponseMessageType: SourceValidator,

--- a/spec_validator_test.go
+++ b/spec_validator_test.go
@@ -18,6 +18,7 @@
 package wrp
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -440,4 +441,38 @@ func TestSpecValidators(t *testing.T) {
 			assert.NoError(err)
 		})
 	}
+}
+
+func ExampleTypeValidator_Validate_specValidators() {
+	msgv, err := NewTypeValidator(
+		// Validates found msg types
+		map[MessageType]Validator{
+			SimpleEventMessageType: SpecValidators,
+			// Only validates Source and nothing else
+			SimpleRequestResponseMessageType: SourceValidator,
+		},
+		// Validates unfound msg types
+		AlwaysInvalid)
+	if err != nil {
+		return
+	}
+
+	foundErrSuccess1 := msgv.Validate(Message{
+		Type:        SimpleEventMessageType,
+		Source:      "MAC:11:22:33:44:55:66",
+		Destination: "MAC:11:22:33:44:55:61",
+	}) // Found success
+	foundErrSuccess2 := msgv.Validate(Message{
+		Type:        SimpleRequestResponseMessageType,
+		Source:      "MAC:11:22:33:44:55:66",
+		Destination: "invalid:a-BB-44-55",
+	}) // Found success
+	foundErrFailure := msgv.Validate(Message{
+		Type:        Invalid0MessageType,
+		Source:      "invalid:a-BB-44-55",
+		Destination: "invalid:a-BB-44-55",
+	}) // Found error
+	unfoundErrFailure := msgv.Validate(Message{Type: CreateMessageType}) // Unfound error
+	fmt.Println(foundErrSuccess1 == nil, foundErrSuccess2 == nil, foundErrFailure == nil, unfoundErrFailure == nil)
+	// Output: true true false false
 }

--- a/spec_validator_test.go
+++ b/spec_validator_test.go
@@ -159,6 +159,16 @@ func testMessageTypeValidator(t *testing.T) {
 			value:       Message{Type: lastMessageType},
 			expectedErr: ErrorInvalidMessageType,
 		},
+		{
+			description: "Non-existing negative MessageType error",
+			value:       Message{Type: -10},
+			expectedErr: ErrorInvalidMessageType,
+		},
+		{
+			description: "Non-existing positive MessageType error",
+			value:       Message{Type: lastMessageType + 1},
+			expectedErr: ErrorInvalidMessageType,
+		},
 	}
 
 	for _, tc := range tests {

--- a/utf8.go
+++ b/utf8.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	ErrNotUTF8        = errors.New("field contains non-utf-8 characters")
-	ErrUnexpectedKind = errors.New("A struct or non-nil pointer to struct is required")
+	ErrUnexpectedKind = errors.New("a struct or non-nil pointer to struct is required")
 )
 
 // UTF8 takes any struct verifies that it contains UTF-8 strings.

--- a/utf8.go
+++ b/utf8.go
@@ -55,7 +55,6 @@ func UTF8(v interface{}) error {
 			if !utf8.ValidString(s) {
 				return fmt.Errorf("%w: '%s:%v'", ErrNotUTF8, ft.Name, s)
 			}
-			fmt.Println(s)
 		}
 	}
 

--- a/validator.go
+++ b/validator.go
@@ -19,6 +19,8 @@ package wrp
 
 import (
 	"errors"
+
+	"go.uber.org/multierr"
 )
 
 var (
@@ -44,14 +46,12 @@ type Validators []Validator
 // Validate runs messages through each validator in the validators list.
 // It returns as soon as the message is considered invalid, otherwise returns nil if valid.
 func (vs Validators) Validate(m Message) error {
+	var err error
 	for _, v := range vs {
-		err := v.Validate(m)
-		if err != nil {
-			return err
-		}
+		err = multierr.Append(err, v.Validate(m))
 	}
 
-	return nil
+	return err
 }
 
 // ValidatorFunc is a WRP validator that takes messages and validates them

--- a/validator.go
+++ b/validator.go
@@ -63,14 +63,14 @@ func (vf ValidatorFunc) Validate(m Message) error {
 }
 
 // TypeValidator is a WRP validator that validates based on message type
-// or using the defaultValidators if message type is unknown.
+// or using the defaultValidators if message type is unfound.
 type TypeValidator struct {
 	m                 map[MessageType]Validators
 	defaultValidators Validators
 }
 
 // Validate validates messages based on message type or using the defaultValidators
-// if message type is unknown.
+// if message type is unfound.
 func (m TypeValidator) Validate(msg Message) error {
 	vs := m.m[msg.MessageType()]
 	if vs == nil {

--- a/validator.go
+++ b/validator.go
@@ -1,0 +1,93 @@
+/**
+ *  Copyright (c) 2022  Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wrp
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrInvalidMsgTypeValidator = errors.New("invalid WRP message type validator")
+	ErrInvalidMsgType          = errors.New("invalid WRP message type")
+)
+
+// Validator is a WRP validator that allows access to the Validate function.
+type Validator interface {
+	Validate(m Message) error
+}
+
+// Validators is a WRP validator that ensures messages are valid based on
+// message type and each validator in the list.
+type Validators []Validator
+
+// ValidatorFunc is a WRP validator that takes messages and validates them
+// against functions.
+type ValidatorFunc func(Message) error
+
+// Validate executes its own ValidatorFunc receiver and returns the result.
+func (vf ValidatorFunc) Validate(m Message) error {
+	return vf(m)
+}
+
+// MsgTypeValidator is a WRP validator that validates based on message type
+// or using the defaultValidator if message type is unknown
+type MsgTypeValidator struct {
+	m                map[MessageType]Validators
+	defaultValidator Validator
+}
+
+// Validate validates messages based on message type or using the defaultValidator
+// if message type is unknown
+func (m MsgTypeValidator) Validate(msg Message) error {
+	vs, ok := m.m[msg.MessageType()]
+	if !ok {
+		return m.defaultValidator.Validate(msg)
+	}
+
+	for _, v := range vs {
+		err := v.Validate(msg)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// NewMsgTypeValidator returns a MsgTypeValidator
+func NewMsgTypeValidator(m map[MessageType]Validators, defaultValidator Validator) (MsgTypeValidator, error) {
+	if m == nil {
+		return MsgTypeValidator{}, fmt.Errorf("%w: %v", ErrInvalidMsgTypeValidator, m)
+	}
+	if defaultValidator == nil {
+		defaultValidator = alwaysInvalidMsg()
+	}
+
+	return MsgTypeValidator{
+		m:                m,
+		defaultValidator: defaultValidator,
+	}, nil
+}
+
+// AlwaysInvalid doesn't validate anything about the message and always returns an error.
+func alwaysInvalidMsg() ValidatorFunc {
+	return func(m Message) error {
+		return fmt.Errorf("%w: %v", ErrInvalidMsgType, m.MessageType().String())
+	}
+}

--- a/validator.go
+++ b/validator.go
@@ -86,9 +86,15 @@ func NewTypeValidator(m map[MessageType]Validators, defaultValidator Validator) 
 		return TypeValidator{}, ErrInvalidTypeValidator
 	}
 
-	for _, v := range m {
-		if v == nil || len(v) == 0 {
+	for _, vs := range m {
+		if vs == nil || len(vs) == 0 {
 			return TypeValidator{}, ErrInvalidTypeValidator
+		}
+
+		for _, v := range vs {
+			if v == nil {
+				return TypeValidator{}, ErrInvalidTypeValidator
+			}
 		}
 	}
 

--- a/validator.go
+++ b/validator.go
@@ -19,7 +19,6 @@ package wrp
 
 import (
 	"errors"
-	"fmt"
 )
 
 var (
@@ -29,7 +28,7 @@ var (
 
 // AlwaysInvalid doesn't validate anything about the message and always returns an error.
 var AlwaysInvalidMsg ValidatorFunc = func(m Message) error {
-	return fmt.Errorf("%w: %v", ErrInvalidMsgType, m.MessageType().String())
+	return ErrInvalidMsgType
 }
 
 // Validator is a WRP validator that allows access to the Validate function.
@@ -78,7 +77,7 @@ func (m MsgTypeValidator) Validate(msg Message) error {
 // NewMsgTypeValidator is a MsgTypeValidator factory.
 func NewMsgTypeValidator(m map[MessageType]Validators, defaultValidator Validator) (MsgTypeValidator, error) {
 	if m == nil {
-		return MsgTypeValidator{}, fmt.Errorf("%w: %v", ErrInvalidMsgTypeValidator, m)
+		return MsgTypeValidator{}, ErrInvalidMsgTypeValidator
 	}
 
 	if defaultValidator == nil {

--- a/validator.go
+++ b/validator.go
@@ -75,6 +75,7 @@ func NewMsgTypeValidator(m map[MessageType]Validators, defaultValidator Validato
 	if m == nil {
 		return MsgTypeValidator{}, fmt.Errorf("%w: %v", ErrInvalidMsgTypeValidator, m)
 	}
+
 	if defaultValidator == nil {
 		defaultValidator = alwaysInvalidMsg()
 	}

--- a/validator.go
+++ b/validator.go
@@ -28,7 +28,7 @@ var (
 )
 
 // AlwaysInvalid doesn't validate anything about the message and always returns an error.
-var alwaysInvalidMsg ValidatorFunc = func(m Message) error {
+var AlwaysInvalidMsg ValidatorFunc = func(m Message) error {
 	return fmt.Errorf("%w: %v", ErrInvalidMsgType, m.MessageType().String())
 }
 
@@ -51,14 +51,14 @@ func (vf ValidatorFunc) Validate(m Message) error {
 }
 
 // MsgTypeValidator is a WRP validator that validates based on message type
-// or using the defaultValidator if message type is unknown
+// or using the defaultValidator if message type is unknown.
 type MsgTypeValidator struct {
 	m                map[MessageType]Validators
 	defaultValidator Validator
 }
 
 // Validate validates messages based on message type or using the defaultValidator
-// if message type is unknown
+// if message type is unknown.
 func (m MsgTypeValidator) Validate(msg Message) error {
 	vs, ok := m.m[msg.MessageType()]
 	if !ok {
@@ -75,14 +75,14 @@ func (m MsgTypeValidator) Validate(msg Message) error {
 	return nil
 }
 
-// NewMsgTypeValidator returns a MsgTypeValidator
+// NewMsgTypeValidator is a MsgTypeValidator factory.
 func NewMsgTypeValidator(m map[MessageType]Validators, defaultValidator Validator) (MsgTypeValidator, error) {
 	if m == nil {
 		return MsgTypeValidator{}, fmt.Errorf("%w: %v", ErrInvalidMsgTypeValidator, m)
 	}
 
 	if defaultValidator == nil {
-		defaultValidator = alwaysInvalidMsg
+		defaultValidator = AlwaysInvalidMsg
 	}
 
 	return MsgTypeValidator{

--- a/validator.go
+++ b/validator.go
@@ -27,6 +27,11 @@ var (
 	ErrInvalidMsgType          = errors.New("invalid WRP message type")
 )
 
+// AlwaysInvalid doesn't validate anything about the message and always returns an error.
+var alwaysInvalidMsg ValidatorFunc = func(m Message) error {
+	return fmt.Errorf("%w: %v", ErrInvalidMsgType, m.MessageType().String())
+}
+
 // Validator is a WRP validator that allows access to the Validate function.
 type Validator interface {
 	Validate(m Message) error
@@ -77,18 +82,11 @@ func NewMsgTypeValidator(m map[MessageType]Validators, defaultValidator Validato
 	}
 
 	if defaultValidator == nil {
-		defaultValidator = alwaysInvalidMsg()
+		defaultValidator = alwaysInvalidMsg
 	}
 
 	return MsgTypeValidator{
 		m:                m,
 		defaultValidator: defaultValidator,
 	}, nil
-}
-
-// AlwaysInvalid doesn't validate anything about the message and always returns an error.
-func alwaysInvalidMsg() ValidatorFunc {
-	return func(m Message) error {
-		return fmt.Errorf("%w: %v", ErrInvalidMsgType, m.MessageType().String())
-	}
 }

--- a/validator.go
+++ b/validator.go
@@ -71,16 +71,11 @@ func (vf ValidatorFunc) Validate(m Message) error {
 type TypeValidator struct {
 	m                 map[MessageType]Validator
 	defaultValidators Validator
-	isbad             bool
 }
 
 // Validate validates messages based on message type or using the defaultValidators
 // if message type is unfound.
 func (m TypeValidator) Validate(msg Message) error {
-	if m.isbad {
-		return ErrInvalidTypeValidator
-	}
-
 	vs := m.m[msg.MessageType()]
 	if vs == nil {
 		return m.defaultValidators.Validate(msg)
@@ -89,15 +84,10 @@ func (m TypeValidator) Validate(msg Message) error {
 	return vs.Validate(msg)
 }
 
-// IsBad returns a boolean indicating whether the TypeValidator receiver is valid
-func (m TypeValidator) IsBad() bool {
-	return m.isbad
-}
-
 // NewTypeValidator is a TypeValidator factory.
 func NewTypeValidator(m map[MessageType]Validator, defaultValidators ...Validator) (TypeValidator, error) {
 	if m == nil {
-		return TypeValidator{isbad: true}, ErrInvalidValidator
+		return TypeValidator{}, ErrInvalidValidator
 	}
 
 	if defaultValidators == nil {

--- a/validator.go
+++ b/validator.go
@@ -19,6 +19,8 @@ package wrp
 
 import (
 	"errors"
+
+	"go.uber.org/multierr"
 )
 
 var (
@@ -27,9 +29,10 @@ var (
 )
 
 // AlwaysInvalid doesn't validate anything about the message and always returns an error.
-var AlwaysInvalid ValidatorFunc = func(m Message) error {
-	return ErrInvalidMsgType
-}
+var AlwaysInvalid ValidatorFunc = func(m Message) error { return ErrInvalidMsgType }
+
+// AlwaysValid doesn't validate anything about the message and always returns nil.
+var AlwaysValid ValidatorFunc = func(msg Message) error { return nil }
 
 // Validator is a WRP validator that allows access to the Validate function.
 type Validator interface {
@@ -43,14 +46,12 @@ type Validators []Validator
 // Validate runs messages through each validator in the validators list.
 // It returns as soon as the message is considered invalid, otherwise returns nil if valid.
 func (vs Validators) Validate(m Message) error {
+	var err error
 	for _, v := range vs {
-		err := v.Validate(m)
-		if err != nil {
-			return err
-		}
+		err = multierr.Append(err, v.Validate(m))
 	}
 
-	return nil
+	return err
 }
 
 // ValidatorFunc is a WRP validator that takes messages and validates them
@@ -63,14 +64,14 @@ func (vf ValidatorFunc) Validate(m Message) error {
 }
 
 // TypeValidator is a WRP validator that validates based on message type
-// or using the defaultValidators if message type is unknown.
+// or using the defaultValidators if message type is unfound.
 type TypeValidator struct {
-	m                 map[MessageType]Validators
+	m                 map[MessageType]Validator
 	defaultValidators Validators
 }
 
 // Validate validates messages based on message type or using the defaultValidators
-// if message type is unknown.
+// if message type is unfound.
 func (m TypeValidator) Validate(msg Message) error {
 	vs := m.m[msg.MessageType()]
 	if vs == nil {
@@ -81,20 +82,14 @@ func (m TypeValidator) Validate(msg Message) error {
 }
 
 // NewTypeValidator is a TypeValidator factory.
-func NewTypeValidator(m map[MessageType]Validators, defaultValidators ...Validator) (TypeValidator, error) {
+func NewTypeValidator(m map[MessageType]Validator, defaultValidators ...Validator) (TypeValidator, error) {
 	if m == nil {
 		return TypeValidator{}, ErrInvalidTypeValidator
 	}
 
-	for _, vs := range m {
-		if vs == nil || len(vs) == 0 {
-			return TypeValidator{}, ErrInvalidTypeValidator
-		}
-
-		for _, v := range vs {
-			if v == nil {
-				return TypeValidator{}, ErrInvalidTypeValidator
-			}
+	for _, v := range m {
+		if err := validateValidator(v); err != nil {
+			return TypeValidator{}, err
 		}
 	}
 
@@ -103,8 +98,8 @@ func NewTypeValidator(m map[MessageType]Validators, defaultValidators ...Validat
 	}
 
 	for _, v := range defaultValidators {
-		if v == nil {
-			return TypeValidator{}, ErrInvalidTypeValidator
+		if err := validateValidator(v); err != nil {
+			return TypeValidator{}, err
 		}
 	}
 
@@ -112,4 +107,26 @@ func NewTypeValidator(m map[MessageType]Validators, defaultValidators ...Validat
 		m:                 m,
 		defaultValidators: defaultValidators,
 	}, nil
+}
+
+// validateValidator validates a given Validator.
+func validateValidator(v Validator) error {
+	switch vs := v.(type) {
+	case Validators:
+		if vs == nil || len(vs) == 0 {
+			return ErrInvalidTypeValidator
+		}
+
+		for _, v := range vs {
+			if v == nil {
+				return ErrInvalidTypeValidator
+			}
+		}
+	case Validator, ValidatorFunc:
+	// catch nil Validator
+	default:
+		return ErrInvalidTypeValidator
+	}
+
+	return nil
 }

--- a/validator.go
+++ b/validator.go
@@ -24,7 +24,8 @@ import (
 )
 
 var (
-	ErrInvalidTypeValidator = errors.New("invalid WRP message type validator")
+	ErrInvalidTypeValidator = errors.New("invalid TypeValidator")
+	ErrInvalidValidator     = errors.New("invalid WRP message type validator")
 	ErrInvalidMsgType       = errors.New("invalid WRP message type")
 )
 
@@ -48,7 +49,9 @@ type Validators []Validator
 func (vs Validators) Validate(m Message) error {
 	var err error
 	for _, v := range vs {
-		err = multierr.Append(err, v.Validate(m))
+		if v != nil {
+			err = multierr.Append(err, v.Validate(m))
+		}
 	}
 
 	return err
@@ -67,12 +70,17 @@ func (vf ValidatorFunc) Validate(m Message) error {
 // or using the defaultValidators if message type is unfound.
 type TypeValidator struct {
 	m                 map[MessageType]Validator
-	defaultValidators Validators
+	defaultValidators Validator
+	isbad             bool
 }
 
 // Validate validates messages based on message type or using the defaultValidators
 // if message type is unfound.
 func (m TypeValidator) Validate(msg Message) error {
+	if m.isbad {
+		return ErrInvalidTypeValidator
+	}
+
 	vs := m.m[msg.MessageType()]
 	if vs == nil {
 		return m.defaultValidators.Validate(msg)
@@ -81,52 +89,23 @@ func (m TypeValidator) Validate(msg Message) error {
 	return vs.Validate(msg)
 }
 
+// IsBad returns a boolean indicating whether the TypeValidator receiver is valid
+func (m TypeValidator) IsBad() bool {
+	return m.isbad
+}
+
 // NewTypeValidator is a TypeValidator factory.
 func NewTypeValidator(m map[MessageType]Validator, defaultValidators ...Validator) (TypeValidator, error) {
 	if m == nil {
-		return TypeValidator{}, ErrInvalidTypeValidator
+		return TypeValidator{isbad: true}, ErrInvalidValidator
 	}
 
-	for _, v := range m {
-		if err := validateValidator(v); err != nil {
-			return TypeValidator{}, err
-		}
-	}
-
-	if len(defaultValidators) == 0 {
+	if defaultValidators == nil {
 		defaultValidators = Validators{AlwaysInvalid}
-	}
-
-	for _, v := range defaultValidators {
-		if err := validateValidator(v); err != nil {
-			return TypeValidator{}, err
-		}
 	}
 
 	return TypeValidator{
 		m:                 m,
-		defaultValidators: defaultValidators,
+		defaultValidators: Validators(defaultValidators),
 	}, nil
-}
-
-// validateValidator validates a given Validator.
-func validateValidator(v Validator) error {
-	switch vs := v.(type) {
-	case Validators:
-		if vs == nil || len(vs) == 0 {
-			return ErrInvalidTypeValidator
-		}
-
-		for _, v := range vs {
-			if v == nil {
-				return ErrInvalidTypeValidator
-			}
-		}
-	case Validator, ValidatorFunc:
-	// catch nil Validator
-	default:
-		return ErrInvalidTypeValidator
-	}
-
-	return nil
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -312,7 +312,7 @@ func testAlwaysValid(t *testing.T) {
 			msg: Message{
 				Type:                    SimpleRequestResponseMessageType,
 				Source:                  "external.com",
-				Destination:             "mac:FFEEAADD44443333",
+				Destination:             "MAC:11:22:33:44:55:66",
 				TransactionUUID:         "DEADBEEF",
 				ContentType:             "ContentType",
 				Accept:                  "Accept",
@@ -339,7 +339,7 @@ func testAlwaysValid(t *testing.T) {
 			msg: Message{
 				Type:        lastMessageType,
 				Source:      "external.com",
-				Destination: "mac:FFEEAADD44443333",
+				Destination: "MAC:11:22:33:44:55:66",
 			},
 		},
 	}
@@ -394,7 +394,7 @@ func testAlwaysInvalid(t *testing.T) {
 			msg: Message{
 				Type:                    SimpleRequestResponseMessageType,
 				Source:                  "external.com",
-				Destination:             "mac:FFEEAADD44443333",
+				Destination:             "MAC:11:22:33:44:55:66",
 				TransactionUUID:         "DEADBEEF",
 				ContentType:             "ContentType",
 				Accept:                  "Accept",
@@ -421,7 +421,7 @@ func testAlwaysInvalid(t *testing.T) {
 			msg: Message{
 				Type:        lastMessageType,
 				Source:      "external.com",
-				Destination: "mac:FFEEAADD44443333",
+				Destination: "MAC:11:22:33:44:55:66",
 			},
 		},
 	}

--- a/validator_test.go
+++ b/validator_test.go
@@ -287,7 +287,7 @@ func testAlwaysValid(t *testing.T) {
 			description: "Not UTF8 success",
 			msg: Message{
 				Type:   SimpleRequestResponseMessageType,
-				Source: "external.com",
+				Source: "dns:external.com",
 				// Not UFT8 Destination string
 				Destination:             "mac:\xed\xbf\xbf",
 				TransactionUUID:         "DEADBEEF",
@@ -307,11 +307,12 @@ func testAlwaysValid(t *testing.T) {
 				SessionID:               "sessionID123",
 			},
 		},
+		// Failure case
 		{
 			description: "Filled message success",
 			msg: Message{
 				Type:                    SimpleRequestResponseMessageType,
-				Source:                  "external.com",
+				Source:                  "dns:external.com",
 				Destination:             "MAC:11:22:33:44:55:66",
 				TransactionUUID:         "DEADBEEF",
 				ContentType:             "ContentType",
@@ -338,7 +339,7 @@ func testAlwaysValid(t *testing.T) {
 			description: "Bad message type success",
 			msg: Message{
 				Type:        lastMessageType + 1,
-				Source:      "external.com",
+				Source:      "dns:external.com",
 				Destination: "MAC:11:22:33:44:55:66",
 			},
 		},
@@ -369,7 +370,7 @@ func testAlwaysInvalid(t *testing.T) {
 			description: "Not UTF8 error",
 			msg: Message{
 				Type:   SimpleRequestResponseMessageType,
-				Source: "external.com",
+				Source: "dns:external.com",
 				// Not UFT8 Destination string
 				Destination:             "mac:\xed\xbf\xbf",
 				TransactionUUID:         "DEADBEEF",
@@ -393,7 +394,7 @@ func testAlwaysInvalid(t *testing.T) {
 			description: "Filled message error",
 			msg: Message{
 				Type:                    SimpleRequestResponseMessageType,
-				Source:                  "external.com",
+				Source:                  "dns:external.com",
 				Destination:             "MAC:11:22:33:44:55:66",
 				TransactionUUID:         "DEADBEEF",
 				ContentType:             "ContentType",
@@ -420,7 +421,7 @@ func testAlwaysInvalid(t *testing.T) {
 			description: "Bad message type error",
 			msg: Message{
 				Type:        lastMessageType + 1,
-				Source:      "external.com",
+				Source:      "dns:external.com",
 				Destination: "MAC:11:22:33:44:55:66",
 			},
 		},
@@ -430,7 +431,7 @@ func testAlwaysInvalid(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
 			err := AlwaysInvalid.Validate(tc.msg)
-			assert.Error(err)
+			assert.ErrorIs(err, ErrInvalidMsgType)
 		})
 	}
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -61,7 +61,7 @@ func testMsgTypeValidatorValidate(t *testing.T) {
 			description: "known message type with failing Validators",
 			value: Test{
 				m: map[MessageType]Validators{
-					SimpleEventMessageType: {alwaysInvalidMsg()},
+					SimpleEventMessageType: {alwaysInvalidMsg},
 				},
 				msg: Message{Type: SimpleEventMessageType},
 			},
@@ -162,10 +162,7 @@ func testNewMsgTypeValidator(t *testing.T) {
 func testAlwaysInvalidMsg(t *testing.T) {
 	assert := assert.New(t)
 	msg := Message{}
-	v := alwaysInvalidMsg()
-
-	assert.NotNil(v)
-	err := v(msg)
+	err := alwaysInvalidMsg(msg)
 
 	assert.NotNil(err)
 	assert.ErrorIs(err, ErrInvalidMsgType)

--- a/validator_test.go
+++ b/validator_test.go
@@ -246,8 +246,8 @@ func ExampleNewTypeValidator() {
 		// Validates unknown msg types
 		AlwaysInvalid)
 
-	fmt.Printf("%v, %T", err == nil, msgv)
-	// Output: true, wrp.TypeValidator
+	fmt.Printf("%v %T", err == nil, msgv)
+	// Output: true wrp.TypeValidator
 
 }
 
@@ -263,6 +263,6 @@ func ExampleTypeValidator_Validate() {
 	}
 	foundErr := msgv.Validate(Message{Type: SimpleEventMessageType}) // Found success
 	unfoundErr := msgv.Validate(Message{Type: CreateMessageType})    // Unfound error
-	fmt.Printf("foundErr is nil: %v, unfoundErr is nil: %v", foundErr == nil, unfoundErr == nil)
-	// Output: foundErr is nil: true, unfoundErr is nil: false
+	fmt.Println(foundErr == nil, unfoundErr == nil)
+	// Output: true false
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -187,6 +187,7 @@ func testNewTypeValidator(t *testing.T) {
 			expectedErr: ErrInvalidTypeValidator,
 		},
 	}
+
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
@@ -206,9 +207,7 @@ func testAlwaysInvalid(t *testing.T) {
 	assert := assert.New(t)
 	msg := Message{}
 	err := AlwaysInvalid(msg)
-
 	assert.ErrorIs(err, ErrInvalidMsgType)
-
 }
 
 func TestHelperValidators(t *testing.T) {
@@ -245,10 +244,8 @@ func ExampleNewTypeValidator() {
 		map[MessageType]Validators{SimpleEventMessageType: {alwaysValid}},
 		// Validates unfound msg types
 		AlwaysInvalid)
-
 	fmt.Printf("%v %T", err == nil, msgv)
 	// Output: true wrp.TypeValidator
-
 }
 
 func ExampleTypeValidator_Validate() {
@@ -261,6 +258,7 @@ func ExampleTypeValidator_Validate() {
 	if err != nil {
 		return
 	}
+
 	foundErr := msgv.Validate(Message{Type: SimpleEventMessageType}) // Found success
 	unfoundErr := msgv.Validate(Message{Type: CreateMessageType})    // Unfound error
 	fmt.Println(foundErr == nil, unfoundErr == nil)

--- a/validator_test.go
+++ b/validator_test.go
@@ -1,0 +1,199 @@
+/**
+ *  Copyright (c) 2022  Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package wrp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func testMsgTypeValidatorValidate(t *testing.T) {
+	type Test struct {
+		m                map[MessageType]Validators
+		defaultValidator Validator
+		msg              Message
+	}
+
+	var alwaysValidMsg ValidatorFunc = func(msg Message) error { return nil }
+	tests := []struct {
+		description string
+		value       Test
+		expectedErr error
+	}{
+		// Success case
+		{
+			description: "known message type with successful Validators",
+			value: Test{
+				m: map[MessageType]Validators{
+					SimpleEventMessageType: {alwaysValidMsg},
+				},
+				msg: Message{Type: SimpleEventMessageType},
+			},
+		},
+		{
+			description: "unknown message type with provided default Validator",
+			value: Test{
+				m: map[MessageType]Validators{
+					SimpleEventMessageType: {alwaysValidMsg},
+				},
+				defaultValidator: alwaysValidMsg,
+				msg:              Message{Type: CreateMessageType},
+			},
+		},
+		// Failure case
+		{
+			description: "known message type with failing Validators",
+			value: Test{
+				m: map[MessageType]Validators{
+					SimpleEventMessageType: {alwaysInvalidMsg()},
+				},
+				msg: Message{Type: SimpleEventMessageType},
+			},
+			expectedErr: ErrInvalidMsgType,
+		},
+		{
+			description: "unknown message type without provided default Validator",
+			value: Test{
+				m: map[MessageType]Validators{
+					SimpleEventMessageType: {alwaysValidMsg},
+				},
+				msg: Message{Type: CreateMessageType},
+			},
+			expectedErr: ErrInvalidMsgType,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			msgv, err := NewMsgTypeValidator(tc.value.m, tc.value.defaultValidator)
+			assert.NotNil(msgv)
+			assert.Nil(err)
+			err = msgv.Validate(tc.value.msg)
+			if tc.expectedErr != nil {
+				assert.ErrorIs(err, tc.expectedErr)
+				return
+			}
+
+			assert.Nil(err)
+		})
+	}
+}
+
+func testNewMsgTypeValidator(t *testing.T) {
+	type Test struct {
+		m                map[MessageType]Validators
+		defaultValidator Validator
+	}
+
+	var alwaysValidMsg ValidatorFunc = func(msg Message) error { return nil }
+	tests := []struct {
+		description string
+		value       Test
+		expectedErr error
+	}{
+		// Success case
+		{
+			description: "with provided default Validator",
+			value: Test{
+				m: map[MessageType]Validators{
+					SimpleEventMessageType: {alwaysValidMsg},
+				},
+				defaultValidator: alwaysValidMsg,
+			},
+			expectedErr: nil,
+		},
+		{
+			description: "without provided default Validator",
+			value: Test{
+				m: map[MessageType]Validators{
+					SimpleEventMessageType: {alwaysValidMsg},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			description: "empty list of message type Validators",
+			value: Test{
+				m: map[MessageType]Validators{
+					SimpleEventMessageType: {},
+				},
+				defaultValidator: alwaysValidMsg,
+			},
+			expectedErr: nil,
+		},
+		// Failure case
+		{
+			description: "missing message type Validators",
+			value:       Test{},
+			expectedErr: ErrInvalidMsgTypeValidator,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			msgv, err := NewMsgTypeValidator(tc.value.m, tc.value.defaultValidator)
+			assert.NotNil(msgv)
+			if tc.expectedErr != nil {
+				assert.ErrorIs(err, tc.expectedErr)
+				return
+			}
+
+			assert.Nil(err)
+		})
+	}
+}
+
+func testAlwaysInvalidMsg(t *testing.T) {
+	assert := assert.New(t)
+	msg := Message{}
+	v := alwaysInvalidMsg()
+
+	assert.NotNil(v)
+	err := v(msg)
+
+	assert.NotNil(err)
+	assert.ErrorIs(err, ErrInvalidMsgType)
+
+}
+
+func TestHelperValidators(t *testing.T) {
+	tests := []struct {
+		name string
+		test func(*testing.T)
+	}{
+		{"alwaysInvalidMsg", testAlwaysInvalidMsg},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, tc.test)
+	}
+}
+
+func TestMsgTypeValidator(t *testing.T) {
+	tests := []struct {
+		name string
+		test func(*testing.T)
+	}{
+		{"MsgTypeValidator validate", testMsgTypeValidatorValidate},
+		{"MsgTypeValidator factory", testNewMsgTypeValidator},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, tc.test)
+	}
+}

--- a/validator_test.go
+++ b/validator_test.go
@@ -18,6 +18,7 @@
 package wrp
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,9 +27,9 @@ import (
 
 func testTypeValidatorValidate(t *testing.T) {
 	type Test struct {
-		m                map[MessageType]Validators
-		defaultValidator Validator
-		msg              Message
+		m                 map[MessageType]Validators
+		defaultValidators Validators
+		msg               Message
 	}
 
 	var alwaysValid ValidatorFunc = func(msg Message) error { return nil }
@@ -53,8 +54,8 @@ func testTypeValidatorValidate(t *testing.T) {
 				m: map[MessageType]Validators{
 					SimpleEventMessageType: {AlwaysInvalid},
 				},
-				defaultValidator: alwaysValid,
-				msg:              Message{Type: CreateMessageType},
+				defaultValidators: Validators{alwaysValid},
+				msg:               Message{Type: CreateMessageType},
 			},
 		},
 		// Failure case
@@ -64,8 +65,8 @@ func testTypeValidatorValidate(t *testing.T) {
 				m: map[MessageType]Validators{
 					SimpleEventMessageType: {AlwaysInvalid},
 				},
-				defaultValidator: alwaysValid,
-				msg:              Message{Type: SimpleEventMessageType},
+				defaultValidators: Validators{alwaysValid},
+				msg:               Message{Type: SimpleEventMessageType},
 			},
 			expectedErr: ErrInvalidMsgType,
 		},
@@ -85,7 +86,7 @@ func testTypeValidatorValidate(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
 			require := require.New(t)
-			msgv, err := NewTypeValidator(tc.value.m, tc.value.defaultValidator)
+			msgv, err := NewTypeValidator(tc.value.m, tc.value.defaultValidators...)
 			require.NotNil(msgv)
 			require.NoError(err)
 			err = msgv.Validate(tc.value.msg)
@@ -101,8 +102,8 @@ func testTypeValidatorValidate(t *testing.T) {
 
 func testNewTypeValidator(t *testing.T) {
 	type Test struct {
-		m                map[MessageType]Validators
-		defaultValidator Validator
+		m                 map[MessageType]Validators
+		defaultValidators Validators
 	}
 
 	var alwaysValid ValidatorFunc = func(msg Message) error { return nil }
@@ -118,15 +119,15 @@ func testNewTypeValidator(t *testing.T) {
 				m: map[MessageType]Validators{
 					SimpleEventMessageType: {alwaysValid},
 				},
-				defaultValidator: alwaysValid,
+				defaultValidators: Validators{alwaysValid},
 			},
 			expectedErr: nil,
 		},
 		{
 			description: "Empty map of Validators success",
 			value: Test{
-				m:                map[MessageType]Validators{},
-				defaultValidator: alwaysValid,
+				m:                 map[MessageType]Validators{},
+				defaultValidators: Validators{alwaysValid},
 			},
 			expectedErr: nil,
 		},
@@ -146,7 +147,7 @@ func testNewTypeValidator(t *testing.T) {
 				m: map[MessageType]Validators{
 					SimpleEventMessageType: {},
 				},
-				defaultValidator: alwaysValid,
+				defaultValidators: Validators{alwaysValid},
 			},
 			expectedErr: ErrInvalidTypeValidator,
 		},
@@ -156,7 +157,7 @@ func testNewTypeValidator(t *testing.T) {
 				m: map[MessageType]Validators{
 					SimpleEventMessageType: nil,
 				},
-				defaultValidator: alwaysValid,
+				defaultValidators: Validators{alwaysValid},
 			},
 			expectedErr: ErrInvalidTypeValidator,
 		},
@@ -166,7 +167,7 @@ func testNewTypeValidator(t *testing.T) {
 				m: map[MessageType]Validators{
 					SimpleEventMessageType: {nil},
 				},
-				defaultValidator: alwaysValid,
+				defaultValidators: Validators{alwaysValid},
 			},
 			expectedErr: ErrInvalidTypeValidator,
 		},
@@ -179,7 +180,7 @@ func testNewTypeValidator(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
-			msgv, err := NewTypeValidator(tc.value.m, tc.value.defaultValidator)
+			msgv, err := NewTypeValidator(tc.value.m, tc.value.defaultValidators...)
 			assert.NotNil(msgv)
 			if tc.expectedErr != nil {
 				assert.ErrorIs(err, tc.expectedErr)
@@ -225,4 +226,43 @@ func TestTypeValidator(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, tc.test)
 	}
+}
+
+func ExampleNewTypeValidator() {
+	var alwaysValid ValidatorFunc = func(msg Message) error { return nil }
+	msgv, err := NewTypeValidator(
+		// Validates known msg types
+		map[MessageType]Validators{SimpleEventMessageType: {alwaysValid}},
+		// Validates unknown msg types
+		AlwaysInvalid)
+	if err != nil {
+		return
+	}
+	err = msgv.Validate(Message{Type: SimpleEventMessageType}) // Found success
+	fmt.Println(err == nil)
+	// Output: true
+
+}
+
+func ExampleTypeValidator_Validate_found() {
+	var alwaysValid ValidatorFunc = func(msg Message) error { return nil }
+	msgv, err := NewTypeValidator(
+		// Validates known msg types
+		map[MessageType]Validators{SimpleEventMessageType: {alwaysValid}},
+		// Validates unknown msg types
+		AlwaysInvalid)
+	err = msgv.Validate(Message{Type: SimpleEventMessageType}) // Found success
+	fmt.Println(err == nil)
+	// Output: true
+}
+func ExampleTypeValidator_Validate_notFound() {
+	var alwaysValid ValidatorFunc = func(msg Message) error { return nil }
+	msgv, err := NewTypeValidator(
+		// Validates known msg types
+		map[MessageType]Validators{SimpleEventMessageType: {alwaysValid}},
+		// Validates unknown msg types
+		AlwaysInvalid)
+	err = msgv.Validate(Message{Type: CreateMessageType}) // Not Found error
+	fmt.Println(err == nil)
+	// Output: false
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -259,14 +259,14 @@ func testTypeValidatorFactory(t *testing.T) {
 			msgv, err := NewTypeValidator(tc.m, tc.defaultValidators...)
 			if tc.expectedErr != nil {
 				assert.ErrorIs(err, tc.expectedErr)
-				assert.NotNil(msgv)
-				assert.NotZero(msgv)
+				// Zero asserts that msgv is the zero value for its type and not nil.
+				assert.Zero(msgv)
 				return
 			}
 
 			assert.NoError(err)
-			// Zero asserts that msgv is the zero value for its type and not nil.
-			assert.Zero(msgv)
+			assert.NotNil(msgv)
+			assert.NotZero(msgv)
 		})
 	}
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -123,7 +123,7 @@ func testNewTypeValidator(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			description: "Empty map of Validator success",
+			description: "Empty map of Validators success",
 			value: Test{
 				m:                map[MessageType]Validators{},
 				defaultValidator: alwaysValid,

--- a/validator_test.go
+++ b/validator_test.go
@@ -202,27 +202,27 @@ func testAlwaysInvalid(t *testing.T) {
 
 func TestHelperValidators(t *testing.T) {
 	tests := []struct {
-		name string
-		test func(*testing.T)
+		description string
+		test        func(*testing.T)
 	}{
 		{"AlwaysInvalid", testAlwaysInvalid},
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, tc.test)
+		t.Run(tc.description, tc.test)
 	}
 }
 
 func TestTypeValidator(t *testing.T) {
 	tests := []struct {
-		name string
-		test func(*testing.T)
+		description string
+		test        func(*testing.T)
 	}{
 		{"TypeValidator validate", testTypeValidatorValidate},
 		{"TypeValidator factory", testNewTypeValidator},
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, tc.test)
+		t.Run(tc.description, tc.test)
 	}
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -337,7 +337,7 @@ func testAlwaysValid(t *testing.T) {
 		{
 			description: "Bad message type success",
 			msg: Message{
-				Type:        lastMessageType,
+				Type:        lastMessageType + 1,
 				Source:      "external.com",
 				Destination: "MAC:11:22:33:44:55:66",
 			},
@@ -419,7 +419,7 @@ func testAlwaysInvalid(t *testing.T) {
 		{
 			description: "Bad message type error",
 			msg: Message{
-				Type:        lastMessageType,
+				Type:        lastMessageType + 1,
 				Source:      "external.com",
 				Destination: "MAC:11:22:33:44:55:66",
 			},

--- a/validator_test.go
+++ b/validator_test.go
@@ -140,7 +140,7 @@ func testNewTypeValidator(t *testing.T) {
 		},
 		// Failure case
 		{
-			description: "Nil list of default Validators error ",
+			description: "Nil list of default Validators error",
 			value: Test{
 				m: map[MessageType]Validator{
 					SimpleEventMessageType: AlwaysValid,

--- a/validator_test.go
+++ b/validator_test.go
@@ -57,14 +57,6 @@ func testTypeValidatorValidate(t *testing.T) {
 				msg:              Message{Type: CreateMessageType},
 			},
 		},
-		{
-			description: "Never found success",
-			value: Test{
-				m:                map[MessageType]Validators{},
-				defaultValidator: alwaysValid,
-				msg:              Message{Type: CreateMessageType},
-			},
-		},
 		// Failure case
 		{
 			description: "Found error",

--- a/validator_test.go
+++ b/validator_test.go
@@ -204,6 +204,13 @@ func testNewTypeValidator(t *testing.T) {
 	}
 }
 
+func testAlwaysValid(t *testing.T) {
+	assert := assert.New(t)
+	msg := Message{}
+	err := AlwaysValid(msg)
+	assert.NoError(err)
+}
+
 func testAlwaysInvalid(t *testing.T) {
 	assert := assert.New(t)
 	msg := Message{}
@@ -217,6 +224,7 @@ func TestHelperValidators(t *testing.T) {
 		test        func(*testing.T)
 	}{
 		{"AlwaysInvalid", testAlwaysInvalid},
+		{"AlwaysValid", testAlwaysValid},
 	}
 
 	for _, tc := range tests {

--- a/validator_test.go
+++ b/validator_test.go
@@ -123,7 +123,7 @@ func testNewTypeValidator(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			description: "Omit map of Validator success",
+			description: "Empty map of Validator success",
 			value: Test{
 				m:                map[MessageType]Validators{},
 				defaultValidator: alwaysValid,

--- a/validator_test.go
+++ b/validator_test.go
@@ -114,7 +114,7 @@ func testNewTypeValidator(t *testing.T) {
 	}{
 		// Success case
 		{
-			description: "Default Validator success",
+			description: "Default Validators success",
 			value: Test{
 				m: map[MessageType]Validators{
 					SimpleEventMessageType: {alwaysValid},
@@ -132,7 +132,7 @@ func testNewTypeValidator(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			description: "Omit default Validator success",
+			description: "Omit default Validators success",
 			value: Test{
 				m: map[MessageType]Validators{
 					SimpleEventMessageType: {alwaysValid},
@@ -141,6 +141,16 @@ func testNewTypeValidator(t *testing.T) {
 			expectedErr: nil,
 		},
 		// Failure case
+		{
+			description: "Nil default Validators",
+			value: Test{
+				m: map[MessageType]Validators{
+					SimpleEventMessageType: {alwaysValid},
+				},
+				defaultValidators: Validators{nil},
+			},
+			expectedErr: ErrInvalidTypeValidator,
+		},
 		{
 			description: "Empty list of Validators error",
 			value: Test{

--- a/validator_test.go
+++ b/validator_test.go
@@ -151,6 +151,26 @@ func testNewTypeValidator(t *testing.T) {
 			expectedErr: ErrInvalidTypeValidator,
 		},
 		{
+			description: "Nil Validators error",
+			value: Test{
+				m: map[MessageType]Validators{
+					SimpleEventMessageType: nil,
+				},
+				defaultValidator: alwaysValid,
+			},
+			expectedErr: ErrInvalidTypeValidator,
+		},
+		{
+			description: "Nil list of Validators error",
+			value: Test{
+				m: map[MessageType]Validators{
+					SimpleEventMessageType: {nil},
+				},
+				defaultValidator: alwaysValid,
+			},
+			expectedErr: ErrInvalidTypeValidator,
+		},
+		{
 			description: "Empty map of Validators error",
 			value:       Test{},
 			expectedErr: ErrInvalidTypeValidator,

--- a/validator_test.go
+++ b/validator_test.go
@@ -116,7 +116,7 @@ func testTypeValidatorValidate(t *testing.T) {
 			msgv, err := NewTypeValidator(tc.m, tc.defaultValidators...)
 			require.NoError(err)
 			require.NotNil(msgv)
-			require.False(msgv.IsBad())
+			assert.NotZero(msgv)
 			err = msgv.Validate(tc.msg)
 			if tc.expectedErr != nil {
 				assert.ErrorIs(err, tc.expectedErr)
@@ -164,16 +164,16 @@ func testTypeValidatorFactory(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
 			msgv, err := NewTypeValidator(tc.m, tc.defaultValidators...)
-			assert.NotNil(msgv)
 			if tc.expectedErr != nil {
 				assert.ErrorIs(err, tc.expectedErr)
-				assert.ErrorIs(msgv.Validate(Message{}), ErrInvalidTypeValidator)
-				assert.True(msgv.IsBad())
+				assert.NotNil(msgv)
+				assert.NotZero(msgv)
 				return
 			}
 
 			assert.NoError(err)
-			assert.False(msgv.IsBad())
+			// Zero asserts that msgv is the zero value for its type and not nil.
+			assert.Zero(msgv)
 		})
 	}
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -241,9 +241,9 @@ func TestTypeValidator(t *testing.T) {
 func ExampleNewTypeValidator() {
 	var alwaysValid ValidatorFunc = func(msg Message) error { return nil }
 	msgv, err := NewTypeValidator(
-		// Validates known msg types
+		// Validates found msg types
 		map[MessageType]Validators{SimpleEventMessageType: {alwaysValid}},
-		// Validates unknown msg types
+		// Validates unfound msg types
 		AlwaysInvalid)
 
 	fmt.Printf("%v %T", err == nil, msgv)

--- a/validator_test.go
+++ b/validator_test.go
@@ -49,7 +49,7 @@ func testTypeValidatorValidate(t *testing.T) {
 			},
 		},
 		{
-			description: "Not found success",
+			description: "Unfound success",
 			value: Test{
 				m: map[MessageType]Validators{
 					SimpleEventMessageType: {AlwaysInvalid},
@@ -71,7 +71,7 @@ func testTypeValidatorValidate(t *testing.T) {
 			expectedErr: ErrInvalidMsgType,
 		},
 		{
-			description: "Not Found error",
+			description: "Unfound error",
 			value: Test{
 				m: map[MessageType]Validators{
 					SimpleEventMessageType: {alwaysValid},
@@ -244,15 +244,15 @@ func ExampleNewTypeValidator() {
 func ExampleTypeValidator_Validate() {
 	var alwaysValid ValidatorFunc = func(msg Message) error { return nil }
 	msgv, err := NewTypeValidator(
-		// Validates known msg types
+		// Validates found msg types
 		map[MessageType]Validators{SimpleEventMessageType: {alwaysValid}},
-		// Validates unknown msg types
+		// Validates unfound msg types
 		AlwaysInvalid)
 	if err != nil {
 		return
 	}
 	foundErr := msgv.Validate(Message{Type: SimpleEventMessageType}) // Found success
-	notFoundErr := msgv.Validate(Message{Type: CreateMessageType})   // Not Found error
-	fmt.Printf("foundErr is nil: %v, notFoundErr is nil: %v", foundErr == nil, notFoundErr == nil)
-	// Output: foundErr is nil: true, notFoundErr is nil: false
+	unfoundErr := msgv.Validate(Message{Type: CreateMessageType})    // Unfound error
+	fmt.Printf("foundErr is nil: %v, unfoundErr is nil: %v", foundErr == nil, unfoundErr == nil)
+	// Output: foundErr is nil: true, unfoundErr is nil: false
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -235,34 +235,24 @@ func ExampleNewTypeValidator() {
 		map[MessageType]Validators{SimpleEventMessageType: {alwaysValid}},
 		// Validates unknown msg types
 		AlwaysInvalid)
+
+	fmt.Printf("%v, %T", err == nil, msgv)
+	// Output: true, wrp.TypeValidator
+
+}
+
+func ExampleTypeValidator_Validate() {
+	var alwaysValid ValidatorFunc = func(msg Message) error { return nil }
+	msgv, err := NewTypeValidator(
+		// Validates known msg types
+		map[MessageType]Validators{SimpleEventMessageType: {alwaysValid}},
+		// Validates unknown msg types
+		AlwaysInvalid)
 	if err != nil {
 		return
 	}
-	err = msgv.Validate(Message{Type: SimpleEventMessageType}) // Found success
-	fmt.Println(err == nil)
-	// Output: true
-
-}
-
-func ExampleTypeValidator_Validate_found() {
-	var alwaysValid ValidatorFunc = func(msg Message) error { return nil }
-	msgv, err := NewTypeValidator(
-		// Validates known msg types
-		map[MessageType]Validators{SimpleEventMessageType: {alwaysValid}},
-		// Validates unknown msg types
-		AlwaysInvalid)
-	err = msgv.Validate(Message{Type: SimpleEventMessageType}) // Found success
-	fmt.Println(err == nil)
-	// Output: true
-}
-func ExampleTypeValidator_Validate_notFound() {
-	var alwaysValid ValidatorFunc = func(msg Message) error { return nil }
-	msgv, err := NewTypeValidator(
-		// Validates known msg types
-		map[MessageType]Validators{SimpleEventMessageType: {alwaysValid}},
-		// Validates unknown msg types
-		AlwaysInvalid)
-	err = msgv.Validate(Message{Type: CreateMessageType}) // Not Found error
-	fmt.Println(err == nil)
-	// Output: false
+	foundErr := msgv.Validate(Message{Type: SimpleEventMessageType}) // Found success
+	notFoundErr := msgv.Validate(Message{Type: CreateMessageType})   // Not Found error
+	fmt.Printf("foundErr is nil: %v, notFoundErr is nil: %v", foundErr == nil, notFoundErr == nil)
+	// Output: foundErr is nil: true, notFoundErr is nil: false
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -61,7 +61,7 @@ func testMsgTypeValidatorValidate(t *testing.T) {
 			description: "known message type with failing Validators",
 			value: Test{
 				m: map[MessageType]Validators{
-					SimpleEventMessageType: {alwaysInvalidMsg},
+					SimpleEventMessageType: {AlwaysInvalidMsg},
 				},
 				msg: Message{Type: SimpleEventMessageType},
 			},
@@ -162,7 +162,7 @@ func testNewMsgTypeValidator(t *testing.T) {
 func testAlwaysInvalidMsg(t *testing.T) {
 	assert := assert.New(t)
 	msg := Message{}
-	err := alwaysInvalidMsg(msg)
+	err := AlwaysInvalidMsg(msg)
 
 	assert.NotNil(err)
 	assert.ErrorIs(err, ErrInvalidMsgType)
@@ -174,7 +174,7 @@ func TestHelperValidators(t *testing.T) {
 		name string
 		test func(*testing.T)
 	}{
-		{"alwaysInvalidMsg", testAlwaysInvalidMsg},
+		{"AlwaysInvalidMsg", testAlwaysInvalidMsg},
 	}
 
 	for _, tc := range tests {

--- a/validator_test.go
+++ b/validator_test.go
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+
 package wrp
 
 import (


### PR DESCRIPTION
## Overview

related to #25, #78, xmidt-org/scytale#88, xmidt-org/talaria#153 and builds on top of #80.

**Note** The diff looks big because we're waiting for #80 , we'll rebase when it's merged.

### tl;dr
This pr introduces our wrp `spec validators` built with our validation framework introduced in #80 which only validates the opinionated portions of the spec. Clients can leverage these prebuilt validators to validate their messages.

<details>
<summary> Explanation</summary>

* Validates requirements described at https://xmidt.io/docs/wrp/basics/#overarching-guidelines
* Validates requirements described at https://xmidt.io/docs/wrp/basics/#locators
* Validates message type values
* Does not cover validators for a specific message type (future prs)

Clients can leverage our prebuilt validators to validate their messages. One set of these validators are our `spec validators`:
```go
msgv, err := NewTypeValidator(
	// Validates found msg types
	map[MessageType]Validator{
		// Validates opinionated portions of the spec
		SimpleEventMessageType: SpecValidators,
		// Only validates Source and nothing else
		SimpleRequestResponseMessageType: SourceValidator,
	},
	// Validates unfound msg types
	AlwaysInvalid)
if err != nil {
	return
}

foundErrSuccess1 := msgv.Validate(Message{
	Type:        SimpleEventMessageType,
	Source:      "MAC:11:22:33:44:55:66",
	Destination: "MAC:11:22:33:44:55:61",
}) // Found success
foundErrSuccess2 := msgv.Validate(Message{
	Type:        SimpleRequestResponseMessageType,
	Source:      "MAC:11:22:33:44:55:66",
	Destination: "invalid:a-BB-44-55",
}) // Found success
foundErrFailure := msgv.Validate(Message{
	Type:        Invalid0MessageType,
	Source:      "invalid:a-BB-44-55",
	Destination: "invalid:a-BB-44-55",
}) // Found error
unfoundErrFailure := msgv.Validate(Message{Type: CreateMessageType}) // Unfound error
fmt.Println(foundErrSuccess1 == nil, foundErrSuccess2 == nil, foundErrFailure == nil, unfoundErrFailure == nil)
// Output: true true false false
```


</details>

<details>
<summary>Type of Change(s)</summary>

- Non-breaking Enhancement
- All new and existing tests passed.

</details>
