### PR TITLE
FR: Add spec validators for the WRP messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-kit/kit v0.8.0
 	github.com/go-logfmt/logfmt v0.3.0 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/google/uuid v1.3.0
 	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/ugorji/go/codec v1.2.6

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/go-logfmt/logfmt v0.3.0 h1:8HUsc87TaSWLKwrnumgC8/YconD2fJQsRJAsWaPg2i
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj2vyii2bbUNDw3kt9VxK2EY=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/spec_validator.go
+++ b/spec_validator.go
@@ -137,6 +137,10 @@ func validateLocator(l string) error {
 		if _, err := uuid.Parse(idPart); err != nil {
 			return err
 		}
+	case serialPrefix, eventPrefix, dnsPrefix:
+		if len(idPart) == 0 {
+			return fmt.Errorf("invalid %v empty authority (ID)", serialPrefix)
+		}
 	}
 
 	return nil

--- a/spec_validator.go
+++ b/spec_validator.go
@@ -49,7 +49,7 @@ var LocatorPattern = regexp.MustCompile(
 )
 
 // SpecValidators is a WRP validator that ensures messages are valid based on
-// each spec validator in the list.
+// each spec validator in the list. Only validates the opinionated portions of the spec.
 var SpecValidators = Validators{UTF8Validator, MessageTypeValidator, SourceValidator, DestinationValidator}
 
 // UTF8Validator is a WRP validator that takes messages and validates that it contains UTF-8 strings.

--- a/spec_validator.go
+++ b/spec_validator.go
@@ -40,59 +40,12 @@ var (
 	ErrorInvalidMessageType     = errors.New("invalid message type")
 	ErrorInvalidSource          = errors.New("invalid Source name")
 	ErrorInvalidDestination     = errors.New("invalid Destination name")
+	errInvalidUUID              = errors.New("invalid UUID")
+	errEmptyAuthority           = errors.New("invalid empty authority (ID)")
+	errInvalidMacLength         = errors.New("invalid mac length")
+	errInvalidCharacter         = errors.New("invalid character")
+	errInvalidLocatorPattern    = errors.New("value given doesn't match expected locator pattern")
 )
-
-// SpecValidators is a WRP validator that ensures messages are valid based on
-// each spec validator in the list. Only validates the opinionated portions of the spec.
-// SpecValidators validates the following fields: UTF8 (all string fields), MessageType, Source, Destination
-func SpecValidators() Validators {
-	return Validators{UTF8Validator, MessageTypeValidator, SourceValidator, DestinationValidator}
-}
-
-// UTF8Validator is a WRP validator that takes messages and validates that it contains UTF-8 strings.
-var UTF8Validator ValidatorFunc = func(m Message) error {
-	if err := UTF8(m); err != nil {
-		return fmt.Errorf("%w: %v", ErrorInvalidMessageEncoding, err)
-	}
-
-	return nil
-}
-
-// MessageTypeValidator is a WRP validator that takes messages and validates their Type.
-var MessageTypeValidator ValidatorFunc = func(m Message) error {
-	if m.Type < Invalid0MessageType || m.Type > lastMessageType {
-		return ErrorInvalidMessageType
-	}
-
-	switch m.Type {
-	case Invalid0MessageType, Invalid1MessageType, lastMessageType:
-		return ErrorInvalidMessageType
-	}
-
-	return nil
-}
-
-// SourceValidator is a WRP validator that takes messages and validates their Source.
-// Only mac and uuid sources are validated. Serial, event and dns sources are
-// not validated.
-var SourceValidator ValidatorFunc = func(m Message) error {
-	if err := validateLocator(m.Source); err != nil {
-		return fmt.Errorf("%w: %v", ErrorInvalidSource, err)
-	}
-
-	return nil
-}
-
-// DestinationValidator is a WRP validator that takes messages and validates their Destination.
-// Only mac and uuid destinations are validated. Serial, event and dns destinations are
-// not validated.
-var DestinationValidator ValidatorFunc = func(m Message) error {
-	if err := validateLocator(m.Destination); err != nil {
-		return fmt.Errorf("%w: %v", ErrorInvalidDestination, err)
-	}
-
-	return nil
-}
 
 // locatorPattern is the precompiled regular expression that all source and dest locators must match.
 // Matching is partial, as everything after the authority (ID) is ignored. https://xmidt.io/docs/wrp/basics/#locators
@@ -100,16 +53,80 @@ var locatorPattern = regexp.MustCompile(
 	`^(?P<scheme>(?i)` + macPrefix + `|` + uuidPrefix + `|` + eventPrefix + `|` + dnsPrefix + `|` + serialPrefix + `):(?P<authority>[^/]+)?`,
 )
 
+// SpecValidators returns a WRP validator that ensures messages are valid based on
+// each spec validator in the list. Only validates the opinionated portions of the spec.
+// SpecValidators validates the following fields: UTF8 (all string fields), MessageType, Source, Destination
+func SpecValidators() Validators {
+	return Validators{UTF8Validator(), MessageTypeValidator(), SourceValidator(), DestinationValidator()}
+}
+
+// UTF8Validator returns a WRP validator that takes messages and validates that it contains UTF-8 strings.
+func UTF8Validator() ValidatorFunc {
+	return func(m Message) error {
+		if err := UTF8(m); err != nil {
+			return fmt.Errorf("%w: %v", ErrorInvalidMessageEncoding, err)
+		}
+
+		return nil
+	}
+}
+
+// MessageTypeValidator returns a WRP validator that takes messages and validates their Type.
+func MessageTypeValidator() ValidatorFunc {
+	return func(m Message) error {
+		if m.Type < Invalid0MessageType || m.Type > lastMessageType {
+			return ErrorInvalidMessageType
+		}
+
+		switch m.Type {
+		case Invalid0MessageType, Invalid1MessageType, lastMessageType:
+			return ErrorInvalidMessageType
+		}
+
+		return nil
+	}
+}
+
+// SourceValidator returns a WRP validator that takes messages and validates their Source.
+// Only mac and uuid sources are validated. Serial, event and dns sources are
+// not validated.
+func SourceValidator() ValidatorFunc {
+	return func(m Message) error {
+		if err := validateLocator(m.Source); err != nil {
+			return fmt.Errorf("%w '%s': %v", ErrorInvalidSource, m.Source, err)
+		}
+
+		return nil
+	}
+}
+
+// DestinationValidator returns a WRP validator that takes messages and validates their Destination.
+// Only mac and uuid destinations are validated. Serial, event and dns destinations are
+// not validated.
+func DestinationValidator() ValidatorFunc {
+	return func(m Message) error {
+		if err := validateLocator(m.Destination); err != nil {
+			return fmt.Errorf("%w '%s': %v", ErrorInvalidDestination, m.Destination, err)
+		}
+
+		return nil
+	}
+}
+
 // validateLocator validates a given locator's scheme and authority (ID).
 // Only mac and uuid schemes' IDs are validated. IDs from serial, event and dns schemes are
 // not validated.
 func validateLocator(l string) error {
 	match := locatorPattern.FindStringSubmatch(l)
 	if match == nil {
-		return fmt.Errorf("spec scheme not found")
+		return errInvalidLocatorPattern
 	}
 
 	idPart := match[2]
+	if len(idPart) == 0 {
+		return errEmptyAuthority
+	}
+
 	switch strings.ToLower(match[1]) {
 	case macPrefix:
 		var invalidCharacter rune = -1
@@ -129,17 +146,13 @@ func validateLocator(l string) error {
 		)
 
 		if invalidCharacter != -1 {
-			return fmt.Errorf("invalid character %v", strconv.QuoteRune(invalidCharacter))
+			return fmt.Errorf("%w: %v", errInvalidCharacter, strconv.QuoteRune(invalidCharacter))
 		} else if len(idPart) != macLength {
-			return errors.New("invalid mac length")
+			return errInvalidMacLength
 		}
 	case uuidPrefix:
 		if _, err := uuid.Parse(idPart); err != nil {
-			return err
-		}
-	case serialPrefix, eventPrefix, dnsPrefix:
-		if len(idPart) == 0 {
-			return fmt.Errorf("invalid empty authority (ID)")
+			return fmt.Errorf("%w: %v", errInvalidUUID, err)
 		}
 	}
 

--- a/spec_validator.go
+++ b/spec_validator.go
@@ -42,12 +42,6 @@ var (
 	ErrorInvalidDestination     = errors.New("invalid Destination name")
 )
 
-// locatorPattern is the precompiled regular expression that all source and dest locators must match.
-// Matching is partial, as everything after the authority (ID) is ignored. https://xmidt.io/docs/wrp/basics/#locators
-var LocatorPattern = regexp.MustCompile(
-	`^(?P<scheme>(?i)` + macPrefix + `|` + uuidPrefix + `|` + eventPrefix + `|` + dnsPrefix + `|` + serialPrefix + `):(?P<authority>[^/]+)?`,
-)
-
 // SpecValidators is a WRP validator that ensures messages are valid based on
 // each spec validator in the list. Only validates the opinionated portions of the spec.
 func SpecValidators() Validators {
@@ -100,11 +94,17 @@ var DestinationValidator ValidatorFunc = func(m Message) error {
 	return nil
 }
 
+// locatorPattern is the precompiled regular expression that all source and dest locators must match.
+// Matching is partial, as everything after the authority (ID) is ignored. https://xmidt.io/docs/wrp/basics/#locators
+var locatorPattern = regexp.MustCompile(
+	`^(?P<scheme>(?i)` + macPrefix + `|` + uuidPrefix + `|` + eventPrefix + `|` + dnsPrefix + `|` + serialPrefix + `):(?P<authority>[^/]+)?`,
+)
+
 // validateLocator validates a given locator's scheme and authority (ID).
 // Only mac and uuid schemes' IDs are validated. IDs from serial, event and dns schemes are
 // not validated.
 func validateLocator(l string) error {
-	match := LocatorPattern.FindStringSubmatch(l)
+	match := locatorPattern.FindStringSubmatch(l)
 	if match == nil {
 		return fmt.Errorf("spec scheme not found")
 	}
@@ -139,7 +139,7 @@ func validateLocator(l string) error {
 		}
 	case serialPrefix, eventPrefix, dnsPrefix:
 		if len(idPart) == 0 {
-			return fmt.Errorf("invalid %v empty authority (ID)", serialPrefix)
+			return fmt.Errorf("invalid empty authority (ID)")
 		}
 	}
 

--- a/spec_validator.go
+++ b/spec_validator.go
@@ -60,12 +60,11 @@ var UTF8Validator ValidatorFunc = func(m Message) error {
 
 // MessageTypeValidator is a WRP validator that takes messages and validates their Type.
 var MessageTypeValidator ValidatorFunc = func(m Message) error {
-	t := m.MessageType()
-	if t < Invalid0MessageType || t > lastMessageType {
+	if m.Type < Invalid0MessageType || m.Type > lastMessageType {
 		return ErrorInvalidMessageType
 	}
 
-	switch t {
+	switch m.Type {
 	case Invalid0MessageType, Invalid1MessageType, lastMessageType:
 		return ErrorInvalidMessageType
 	}

--- a/spec_validator.go
+++ b/spec_validator.go
@@ -44,6 +44,7 @@ var (
 
 // SpecValidators is a WRP validator that ensures messages are valid based on
 // each spec validator in the list. Only validates the opinionated portions of the spec.
+// SpecValidators validates the following fields: UTF8 (all string fields), MessageType, Source, Destination
 func SpecValidators() Validators {
 	return Validators{UTF8Validator, MessageTypeValidator, SourceValidator, DestinationValidator}
 }

--- a/spec_validator_test.go
+++ b/spec_validator_test.go
@@ -96,9 +96,8 @@ func TestSpecValidators(t *testing.T) {
 				Spans:                   [][]string{{"1", "2"}, {"3"}},
 				IncludeSpans:            &expectedIncludeSpans,
 				Path:                    "/some/where/over/the/rainbow",
-				// Not UFT8 Payload
-				Payload:     []byte{1, 2, 3, 4, 0xff /* \xed\xbf\xbf is invalid */, 0xce},
-				ServiceName: "ServiceName",
+				Payload:                 []byte{1, 2, 3, 4, 0xff, 0xce},
+				ServiceName:             "ServiceName",
 				// Not UFT8 URL string
 				URL:        "someURL\xed\xbf\xbf.com",
 				PartnerIDs: []string{"foo"},

--- a/spec_validator_test.go
+++ b/spec_validator_test.go
@@ -61,7 +61,7 @@ func testUTF8Validator(t *testing.T) {
 		{
 			description: "Not UTF8 error",
 			value:       *msg,
-			expectedErr: []error{ErrorInvalidMessageEncoding, ErrNotUTF8},
+			expectedErr: []error{ErrorInvalidMessageEncoding},
 		},
 	}
 
@@ -189,7 +189,7 @@ func testSourceValidator(t *testing.T) {
 	tests := []struct {
 		description string
 		value       Message
-		expectedErr []error
+		expectedErr error
 	}{
 		// Success case
 		{
@@ -201,7 +201,7 @@ func testSourceValidator(t *testing.T) {
 		{
 			description: "Source error",
 			value:       Message{Source: "invalid:a-BB-44-55"},
-			expectedErr: []error{ErrorInvalidSource, ErrorInvalidLocator},
+			expectedErr: ErrorInvalidSource,
 		},
 	}
 
@@ -210,9 +210,7 @@ func testSourceValidator(t *testing.T) {
 			assert := assert.New(t)
 			err := SourceValidator(tc.value)
 			if tc.expectedErr != nil {
-				for _, e := range tc.expectedErr {
-					assert.ErrorIs(err, e)
-				}
+				assert.ErrorIs(err, tc.expectedErr)
 				return
 			}
 
@@ -225,7 +223,7 @@ func testDestinationValidator(t *testing.T) {
 	tests := []struct {
 		description string
 		value       Message
-		expectedErr []error
+		expectedErr error
 	}{
 		// Success case
 		{
@@ -237,7 +235,7 @@ func testDestinationValidator(t *testing.T) {
 		{
 			description: "Destination error",
 			value:       Message{Destination: "invalid:a-BB-44-55"},
-			expectedErr: []error{ErrorInvalidDestination, ErrorInvalidLocator},
+			expectedErr: ErrorInvalidDestination,
 		},
 	}
 
@@ -246,9 +244,7 @@ func testDestinationValidator(t *testing.T) {
 			assert := assert.New(t)
 			err := DestinationValidator(tc.value)
 			if tc.expectedErr != nil {
-				for _, e := range tc.expectedErr {
-					assert.ErrorIs(err, e)
-				}
+				assert.ErrorIs(err, tc.expectedErr)
 				return
 			}
 
@@ -261,120 +257,120 @@ func testValidateLocator(t *testing.T) {
 	tests := []struct {
 		description string
 		value       string
-		expectedErr error
+		shouldErr   bool
 	}{
 		// mac success case
 		{
 			description: "Mac ID ':' delimiter success",
 			value:       "MAC:11:22:33:44:55:66",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		{
 			description: "Mac ID no delimiter success",
 			value:       "MAC:11aaBB445566",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		{
 			description: "Mac ID '-' delimiter success",
 			value:       "mac:11-aa-BB-44-55-66",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		{
 			description: "Mac ID ',' delimiter success",
 			value:       "mac:11,aa,BB,44,55,66",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		{
 			description: "Mac with service success",
 			value:       "mac:11,aa,BB,44,55,66/parodus/tag/test0",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		// Mac failure case
 		{
 			description: "Invalid mac ID character error",
 			value:       "MAC:invalid45566",
-			expectedErr: ErrorInvalidLocator,
+			shouldErr:   true,
 		},
 		{
 			description: "Invalid mac ID length error",
 			value:       "mac:11-aa-BB-44-55",
-			expectedErr: ErrorInvalidLocator,
+			shouldErr:   true,
 		},
 		// Serial success case
 		{
 			description: "Serial ID success",
 			value:       "serial:anything Goes!",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		// UUID success case
 		{
 			description: "UUID RFC4122 variant ID success", // The variant specified in RFC4122
 			value:       "uuid:f47ac10b-58cc-0372-8567-0e02b2c3d479",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		{
 			description: "UUID RFC4122 variant with Microsoft encoding ID success", // The variant specified in RFC4122
 			value:       "uuid:{f47ac10b-58cc-0372-8567-0e02b2c3d479}",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		{
 			description: "UUID Reserved variant ID #1 success", // Reserved, NCS backward compatibility.
 			value:       "UUID:urn:uuid:f47ac10b-58cc-4372-0567-0e02b2c3d479",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		{
 			description: "UUID Reserved variant ID #2 success", // Reserved, NCS backward compatibility.
 			value:       "UUID:URN:UUID:f47ac10b-58cc-4372-0567-0e02b2c3d479",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		{
 			description: "UUID Reserved variant ID #3 success", // Reserved, NCS backward compatibility.
 			value:       "UUID:f47ac10b-58cc-4372-0567-0e02b2c3d479",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		{
 			description: "UUID Microsoft variant ID success", // Reserved, Microsoft Corporation backward compatibility.
 			value:       "uuid:f47ac10b-58cc-4372-c567-0e02b2c3d479",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		{
 			description: "UUID Future variant ID success", // Reserved for future definition.
 			value:       "uuid:f47ac10b-58cc-4372-e567-0e02b2c3d479",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		// UUID failure case
 		{
 			description: "Invalid UUID ID #1 error",
 			value:       "uuid:invalid45566",
-			expectedErr: ErrorInvalidLocator,
+			shouldErr:   true,
 		},
 		{
 			description: "Invalid UUID ID #2 error",
 			value:       "uuid:URN:UUID:invalid45566",
-			expectedErr: ErrorInvalidLocator,
+			shouldErr:   true,
 		},
 		{
 			description: "Invalid UUID ID #3 error",
 			value:       "uuid:{invalid45566}",
-			expectedErr: ErrorInvalidLocator,
+			shouldErr:   true,
 		},
 		// Event success case
 		{
 			description: "Event ID success",
 			value:       "event:anything Goes!",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		// DNS success case
 		{
 			description: "DNS ID success",
 			value:       "dns:anything Goes!",
-			expectedErr: nil,
+			shouldErr:   false,
 		},
 		// Scheme failure case
 		{
 			description: "Invalid scheme error",
 			value:       "invalid:a-BB-44-55",
-			expectedErr: ErrorInvalidLocator,
+			shouldErr:   true,
 		},
 	}
 
@@ -382,8 +378,8 @@ func testValidateLocator(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
 			err := validateLocator(tc.value)
-			if tc.expectedErr != nil {
-				assert.ErrorIs(err, tc.expectedErr)
+			if tc.shouldErr {
+				assert.Error(err)
 				return
 			}
 
@@ -433,14 +429,14 @@ func TestSpecValidators(t *testing.T) {
 				Source:      "invalid:a-BB-44-55",
 				Destination: "invalid:a-BB-44-55",
 			},
-			expectedErr: []error{ErrorInvalidMessageType, ErrorInvalidSource, ErrorInvalidLocator, ErrorInvalidDestination},
+			expectedErr: []error{ErrorInvalidMessageType, ErrorInvalidSource, ErrorInvalidDestination},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
-			err := SpecValidators.Validate(tc.value)
+			err := SpecValidators().Validate(tc.value)
 			if tc.expectedErr != nil {
 				for _, e := range tc.expectedErr {
 					assert.ErrorIs(err, e)
@@ -458,7 +454,7 @@ func ExampleTypeValidator_Validate_specValidators() {
 		// Validates found msg types
 		map[MessageType]Validator{
 			// Validates opinionated portions of the spec
-			SimpleEventMessageType: SpecValidators,
+			SimpleEventMessageType: SpecValidators(),
 			// Only validates Source and nothing else
 			SimpleRequestResponseMessageType: SourceValidator,
 		},

--- a/spec_validator_test.go
+++ b/spec_validator_test.go
@@ -1,0 +1,443 @@
+/**
+ *  Copyright (c) 2022  Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wrp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testUTF8Validator(t *testing.T) {
+	/*
+		"\x85"  - 5 name value pairs
+			"\xa8""msg_type"         : "\x03" // 3
+			"\xa4""dest"             : "\xac""\xed\xbf\xbft-address"
+			"\xa7""payload"          : "\xc4""\x03" - len 3
+											 "123"
+			"\xa6""source"           : "\xae""source-address"
+			"\xb0""transaction_uuid" : "\xd9\x24""c07ee5e1-70be-444c-a156-097c767ad8aa"
+	*/
+	invalid := []byte{
+		0x85,
+		0xa8, 'm', 's', 'g', '_', 't', 'y', 'p', 'e', 0x03,
+		0xa4, 'd', 'e', 's', 't', 0xac /* \xed\xbf\xbf is invalid */, 0xed, 0xbf, 0xbf, 't', '-', 'a', 'd', 'd', 'r', 'e', 's', 's',
+		0xa7, 'p', 'a', 'y', 'l', 'o', 'a', 'd', 0xc4, 0x03, '1', '2', '3',
+		0xa6, 's', 'o', 'u', 'r', 'c', 'e', 0xae, 's', 'o', 'u', 'r', 'c', 'e', '-', 'a', 'd', 'd', 'r', 'e', 's', 's',
+		0xb0, 't', 'r', 'a', 'n', 's', 'a', 'c', 't', 'i', 'o', 'n', '_', 'u', 'u', 'i', 'd', 0xd9, 0x24, 'c', '0', '7', 'e', 'e', '5', 'e', '1', '-', '7', '0', 'b', 'e', '-', '4', '4', '4', 'c', '-', 'a', '1', '5', '6', '-', '0', '9', '7', 'c', '7', '6', '7', 'a', 'd', '8', 'a', 'a',
+	}
+	decoder := NewDecoderBytes(invalid, Msgpack)
+	msg := new(Message)
+	err := decoder.Decode(msg)
+	require.NoError(t, err)
+	tests := []struct {
+		description string
+		value       Message
+		expectedErr []error
+	}{
+		// Success case
+		{
+			description: "UTF8 success",
+			value:       Message{Source: "MAC:11:22:33:44:55:66"},
+			expectedErr: nil,
+		},
+		{
+			description: "Not UTF8 error",
+			value:       *msg,
+			expectedErr: []error{ErrorInvalidMessageEncoding, ErrNotUTF8},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			err := UTF8Validator(tc.value)
+			if tc.expectedErr != nil {
+				for _, e := range tc.expectedErr {
+					assert.ErrorIs(err, e)
+				}
+				return
+			}
+
+			assert.NoError(err)
+		})
+	}
+}
+
+func testMessageTypeValidator(t *testing.T) {
+	tests := []struct {
+		description string
+		value       Message
+		expectedErr error
+	}{
+		// Success case
+		{
+			description: "AuthorizationMessageType success",
+			value:       Message{Type: AuthorizationMessageType},
+			expectedErr: nil,
+		},
+		{
+			description: "SimpleRequestResponseMessageType success",
+			value:       Message{Type: SimpleRequestResponseMessageType},
+			expectedErr: nil,
+		},
+		{
+			description: "SimpleEventMessageType success",
+			value:       Message{Type: SimpleEventMessageType},
+			expectedErr: nil,
+		},
+		{
+			description: "CreateMessageType success",
+			value:       Message{Type: CreateMessageType},
+			expectedErr: nil,
+		},
+		{
+			description: "RetrieveMessageType success",
+			value:       Message{Type: RetrieveMessageType},
+			expectedErr: nil,
+		},
+		{
+			description: "UpdateMessageType success",
+			value:       Message{Type: UpdateMessageType},
+			expectedErr: nil,
+		},
+		{
+			description: "DeleteMessageType success",
+			value:       Message{Type: DeleteMessageType},
+			expectedErr: nil,
+		},
+		{
+			description: "ServiceRegistrationMessageType success",
+			value:       Message{Type: ServiceRegistrationMessageType},
+			expectedErr: nil,
+		},
+		{
+			description: "ServiceAliveMessageType success",
+			value:       Message{Type: ServiceAliveMessageType},
+			expectedErr: nil,
+		},
+		{
+			description: "UnknownMessageType success",
+			value:       Message{Type: UnknownMessageType},
+			expectedErr: nil,
+		},
+		// Failure case
+		{
+			description: "Invalid0MessageType error",
+			value:       Message{Type: Invalid0MessageType},
+			expectedErr: ErrorInvalidMessageType,
+		},
+		{
+			description: "Invalid0MessageType error",
+			value:       Message{Type: Invalid0MessageType},
+			expectedErr: ErrorInvalidMessageType,
+		},
+		{
+			description: "Invalid1MessageType error",
+			value:       Message{Type: Invalid1MessageType},
+			expectedErr: ErrorInvalidMessageType,
+		},
+		{
+			description: "lastMessageType error",
+			value:       Message{Type: lastMessageType},
+			expectedErr: ErrorInvalidMessageType,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			err := MessageTypeValidator(tc.value)
+			if tc.expectedErr != nil {
+				assert.ErrorIs(err, tc.expectedErr)
+				return
+			}
+
+			assert.NoError(err)
+		})
+	}
+}
+
+func testSourceValidator(t *testing.T) {
+	tests := []struct {
+		description string
+		value       Message
+		expectedErr []error
+	}{
+		// Success case
+		{
+			description: "Source success",
+			value:       Message{Source: "MAC:11:22:33:44:55:66"},
+			expectedErr: nil,
+		},
+		// Failures
+		{
+			description: "Source error",
+			value:       Message{Source: "invalid:a-BB-44-55"},
+			expectedErr: []error{ErrorInvalidSource, ErrorInvalidLocator},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			err := SourceValidator(tc.value)
+			if tc.expectedErr != nil {
+				for _, e := range tc.expectedErr {
+					assert.ErrorIs(err, e)
+				}
+				return
+			}
+
+			assert.NoError(err)
+		})
+	}
+}
+
+func testDestinationValidator(t *testing.T) {
+	tests := []struct {
+		description string
+		value       Message
+		expectedErr []error
+	}{
+		// Success case
+		{
+			description: "Destination success",
+			value:       Message{Destination: "MAC:11:22:33:44:55:66"},
+			expectedErr: nil,
+		},
+		// Failures
+		{
+			description: "Destination error",
+			value:       Message{Destination: "invalid:a-BB-44-55"},
+			expectedErr: []error{ErrorInvalidDestination, ErrorInvalidLocator},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			err := DestinationValidator(tc.value)
+			if tc.expectedErr != nil {
+				for _, e := range tc.expectedErr {
+					assert.ErrorIs(err, e)
+				}
+				return
+			}
+
+			assert.NoError(err)
+		})
+	}
+}
+
+func testValidateLocator(t *testing.T) {
+	tests := []struct {
+		description string
+		value       string
+		expectedErr error
+	}{
+		// mac success case
+		{
+			description: "Mac ID ':' delimiter success",
+			value:       "MAC:11:22:33:44:55:66",
+			expectedErr: nil,
+		},
+		{
+			description: "Mac ID no delimiter success",
+			value:       "MAC:11aaBB445566",
+			expectedErr: nil,
+		},
+		{
+			description: "Mac ID '-' delimiter success",
+			value:       "mac:11-aa-BB-44-55-66",
+			expectedErr: nil,
+		},
+		{
+			description: "Mac ID ',' delimiter success",
+			value:       "mac:11,aa,BB,44,55,66",
+			expectedErr: nil,
+		},
+		{
+			description: "Mac with service success",
+			value:       "mac:11,aa,BB,44,55,66/parodus/tag/test0",
+			expectedErr: nil,
+		},
+		// Mac failure case
+		{
+			description: "Invalid mac ID character error",
+			value:       "MAC:invalid45566",
+			expectedErr: ErrorInvalidLocator,
+		},
+		{
+			description: "Invalid mac ID length error",
+			value:       "mac:11-aa-BB-44-55",
+			expectedErr: ErrorInvalidLocator,
+		},
+		// Serial success case
+		{
+			description: "Serial ID success",
+			value:       "serial:anything Goes!",
+			expectedErr: nil,
+		},
+		// UUID success case
+		{
+			description: "UUID RFC4122 variant ID success", // The variant specified in RFC4122
+			value:       "uuid:f47ac10b-58cc-0372-8567-0e02b2c3d479",
+			expectedErr: nil,
+		},
+		{
+			description: "UUID RFC4122 variant with Microsoft encoding ID success", // The variant specified in RFC4122
+			value:       "uuid:{f47ac10b-58cc-0372-8567-0e02b2c3d479}",
+			expectedErr: nil,
+		},
+		{
+			description: "UUID Reserved variant ID #1 success", // Reserved, NCS backward compatibility.
+			value:       "UUID:urn:uuid:f47ac10b-58cc-4372-0567-0e02b2c3d479",
+			expectedErr: nil,
+		},
+		{
+			description: "UUID Reserved variant ID #2 success", // Reserved, NCS backward compatibility.
+			value:       "UUID:URN:UUID:f47ac10b-58cc-4372-0567-0e02b2c3d479",
+			expectedErr: nil,
+		},
+		{
+			description: "UUID Reserved variant ID #3 success", // Reserved, NCS backward compatibility.
+			value:       "UUID:f47ac10b-58cc-4372-0567-0e02b2c3d479",
+			expectedErr: nil,
+		},
+		{
+			description: "UUID Microsoft variant ID success", // Reserved, Microsoft Corporation backward compatibility.
+			value:       "uuid:f47ac10b-58cc-4372-c567-0e02b2c3d479",
+			expectedErr: nil,
+		},
+		{
+			description: "UUID Future variant ID success", // Reserved for future definition.
+			value:       "uuid:f47ac10b-58cc-4372-e567-0e02b2c3d479",
+			expectedErr: nil,
+		},
+		// UUID failure case
+		{
+			description: "Invalid UUID ID #1 error",
+			value:       "uuid:invalid45566",
+			expectedErr: ErrorInvalidLocator,
+		},
+		{
+			description: "Invalid UUID ID #2 error",
+			value:       "uuid:URN:UUID:invalid45566",
+			expectedErr: ErrorInvalidLocator,
+		},
+		{
+			description: "Invalid UUID ID #3 error",
+			value:       "uuid:{invalid45566}",
+			expectedErr: ErrorInvalidLocator,
+		},
+		// Event success case
+		{
+			description: "Event ID success",
+			value:       "event:anything Goes!",
+			expectedErr: nil,
+		},
+		// DNS success case
+		{
+			description: "DNS ID success",
+			value:       "dns:anything Goes!",
+			expectedErr: nil,
+		},
+		// Scheme failure case
+		{
+			description: "Invalid scheme error",
+			value:       "invalid:a-BB-44-55",
+			expectedErr: ErrorInvalidLocator,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			err := validateLocator(tc.value)
+			if tc.expectedErr != nil {
+				assert.ErrorIs(err, tc.expectedErr)
+				return
+			}
+
+			assert.NoError(err)
+		})
+	}
+}
+
+func TestSpecHelperValidators(t *testing.T) {
+	tests := []struct {
+		description string
+		test        func(*testing.T)
+	}{
+		{"UTF8Validator", testUTF8Validator},
+		{"MessageTypeValidator", testMessageTypeValidator},
+		{"SourceValidator", testSourceValidator},
+		{"DestinationValidator", testDestinationValidator},
+		{"validateLocator", testValidateLocator},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, tc.test)
+	}
+}
+
+func TestSpecValidators(t *testing.T) {
+	tests := []struct {
+		description string
+		value       Message
+		expectedErr []error
+	}{
+		// Success case
+		{
+			description: "Valid specs success",
+			value: Message{
+				Type:        SimpleEventMessageType,
+				Source:      "MAC:11:22:33:44:55:66",
+				Destination: "MAC:11:22:33:44:55:66",
+			},
+			expectedErr: nil,
+		},
+		// Failure cases
+		{
+			description: "Invaild specs error",
+			value: Message{
+				Type:        Invalid0MessageType,
+				Source:      "invalid:a-BB-44-55",
+				Destination: "invalid:a-BB-44-55",
+			},
+			expectedErr: []error{ErrorInvalidMessageType, ErrorInvalidSource, ErrorInvalidLocator, ErrorInvalidDestination},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			err := SpecValidators.Validate(tc.value)
+			if tc.expectedErr != nil {
+				for _, e := range tc.expectedErr {
+					assert.ErrorIs(err, e)
+				}
+				return
+			}
+
+			assert.NoError(err)
+		})
+	}
+}

--- a/spec_validator_test.go
+++ b/spec_validator_test.go
@@ -457,6 +457,7 @@ func ExampleTypeValidator_Validate_specValidators() {
 	msgv, err := NewTypeValidator(
 		// Validates found msg types
 		map[MessageType]Validator{
+			// Validates opinionated portions of the spec
 			SimpleEventMessageType: SpecValidators,
 			// Only validates Source and nothing else
 			SimpleRequestResponseMessageType: SourceValidator,

--- a/spec_validator_test.go
+++ b/spec_validator_test.go
@@ -18,6 +18,7 @@
 package wrp
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -440,4 +441,38 @@ func TestSpecValidators(t *testing.T) {
 			assert.NoError(err)
 		})
 	}
+}
+
+func ExampleTypeValidator_Validate_specValidators() {
+	msgv, err := NewTypeValidator(
+		// Validates found msg types
+		map[MessageType]Validator{
+			SimpleEventMessageType: SpecValidators,
+			// Only validates Source and nothing else
+			SimpleRequestResponseMessageType: SourceValidator,
+		},
+		// Validates unfound msg types
+		AlwaysInvalid)
+	if err != nil {
+		return
+	}
+
+	foundErrSuccess1 := msgv.Validate(Message{
+		Type:        SimpleEventMessageType,
+		Source:      "MAC:11:22:33:44:55:66",
+		Destination: "MAC:11:22:33:44:55:61",
+	}) // Found success
+	foundErrSuccess2 := msgv.Validate(Message{
+		Type:        SimpleRequestResponseMessageType,
+		Source:      "MAC:11:22:33:44:55:66",
+		Destination: "invalid:a-BB-44-55",
+	}) // Found success
+	foundErrFailure := msgv.Validate(Message{
+		Type:        Invalid0MessageType,
+		Source:      "invalid:a-BB-44-55",
+		Destination: "invalid:a-BB-44-55",
+	}) // Found error
+	unfoundErrFailure := msgv.Validate(Message{Type: CreateMessageType}) // Unfound error
+	fmt.Println(foundErrSuccess1 == nil, foundErrSuccess2 == nil, foundErrFailure == nil, unfoundErrFailure == nil)
+	// Output: true true false false
 }

--- a/spec_validator_test.go
+++ b/spec_validator_test.go
@@ -159,6 +159,16 @@ func testMessageTypeValidator(t *testing.T) {
 			value:       Message{Type: lastMessageType},
 			expectedErr: ErrorInvalidMessageType,
 		},
+		{
+			description: "Non-existing negative MessageType error",
+			value:       Message{Type: -10},
+			expectedErr: ErrorInvalidMessageType,
+		},
+		{
+			description: "Non-existing positive MessageType error",
+			value:       Message{Type: lastMessageType + 1},
+			expectedErr: ErrorInvalidMessageType,
+		},
 	}
 
 	for _, tc := range tests {

--- a/utf8.go
+++ b/utf8.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	ErrNotUTF8        = errors.New("field contains non-utf-8 characters")
-	ErrUnexpectedKind = errors.New("A struct or non-nil pointer to struct is required")
+	ErrUnexpectedKind = errors.New("a struct or non-nil pointer to struct is required")
 )
 
 // UTF8 takes any struct verifies that it contains UTF-8 strings.

--- a/utf8.go
+++ b/utf8.go
@@ -55,7 +55,6 @@ func UTF8(v interface{}) error {
 			if !utf8.ValidString(s) {
 				return fmt.Errorf("%w: '%s:%v'", ErrNotUTF8, ft.Name, s)
 			}
-			fmt.Println(s)
 		}
 	}
 

--- a/validator.go
+++ b/validator.go
@@ -29,12 +29,6 @@ var (
 	ErrInvalidMsgType       = errors.New("invalid WRP message type")
 )
 
-// AlwaysInvalid doesn't validate anything about the message and always returns an error.
-var AlwaysInvalid ValidatorFunc = func(m Message) error { return ErrInvalidMsgType }
-
-// AlwaysValid doesn't validate anything about the message and always returns nil.
-var AlwaysValid ValidatorFunc = func(msg Message) error { return nil }
-
 // Validator is a WRP validator that allows access to the Validate function.
 type Validator interface {
 	Validate(m Message) error
@@ -91,11 +85,21 @@ func NewTypeValidator(m map[MessageType]Validator, defaultValidator Validator) (
 	}
 
 	if defaultValidator == nil {
-		defaultValidator = AlwaysInvalid
+		defaultValidator = AlwaysInvalid()
 	}
 
 	return TypeValidator{
 		m:                m,
 		defaultValidator: defaultValidator,
 	}, nil
+}
+
+// AlwaysInvalid returns a WRP validator that doesn't validate anything about the message and always returns an error.
+func AlwaysInvalid() ValidatorFunc {
+	return func(_ Message) error { return ErrInvalidMsgType }
+}
+
+// AlwaysValid returns a WRP validator that doesn't validate anything about the message and always returns nil.
+func AlwaysValid() ValidatorFunc {
+	return func(_ Message) error { return nil }
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -42,7 +42,7 @@ func TestValidators(t *testing.T) {
 		// Failure case
 		{
 			description: "Mix Validators error",
-			vs:          Validators{AlwaysValid, nil, AlwaysInvalid, Validators{AlwaysValid, nil, AlwaysInvalid}},
+			vs:          Validators{AlwaysValid(), nil, AlwaysInvalid(), Validators{AlwaysValid(), nil, AlwaysInvalid()}},
 			msg:         Message{Type: SimpleEventMessageType},
 			expectedErr: []error{ErrInvalidMsgType, ErrInvalidMsgType},
 		},
@@ -96,9 +96,9 @@ func TestTypeValidator(t *testing.T) {
 func ExampleNewTypeValidator() {
 	msgv, err := NewTypeValidator(
 		// Validates found msg types
-		map[MessageType]Validator{SimpleEventMessageType: AlwaysValid},
+		map[MessageType]Validator{SimpleEventMessageType: AlwaysValid()},
 		// Validates unfound msg types
-		AlwaysInvalid)
+		AlwaysInvalid())
 	fmt.Printf("%v %T", err == nil, msgv)
 	// Output: true wrp.TypeValidator
 }
@@ -106,9 +106,9 @@ func ExampleNewTypeValidator() {
 func ExampleTypeValidator_Validate() {
 	msgv, err := NewTypeValidator(
 		// Validates found msg types
-		map[MessageType]Validator{SimpleEventMessageType: AlwaysValid},
+		map[MessageType]Validator{SimpleEventMessageType: AlwaysValid()},
 		// Validates unfound msg types
-		AlwaysInvalid)
+		AlwaysInvalid())
 	if err != nil {
 		return
 	}
@@ -131,22 +131,22 @@ func testTypeValidatorValidate(t *testing.T) {
 		{
 			description: "Found success",
 			m: map[MessageType]Validator{
-				SimpleEventMessageType: AlwaysValid,
+				SimpleEventMessageType: AlwaysValid(),
 			},
 			msg: Message{Type: SimpleEventMessageType},
 		},
 		{
 			description: "Unfound success",
 			m: map[MessageType]Validator{
-				SimpleEventMessageType: AlwaysInvalid,
+				SimpleEventMessageType: AlwaysInvalid(),
 			},
-			defaultValidator: AlwaysValid,
+			defaultValidator: AlwaysValid(),
 			msg:              Message{Type: CreateMessageType},
 		},
 		{
 			description: "Unfound success, nil list of default Validators",
 			m: map[MessageType]Validator{
-				SimpleEventMessageType: AlwaysInvalid,
+				SimpleEventMessageType: AlwaysInvalid(),
 			},
 			defaultValidator: Validators{nil},
 			msg:              Message{Type: CreateMessageType},
@@ -154,7 +154,7 @@ func testTypeValidatorValidate(t *testing.T) {
 		{
 			description: "Unfound success, empty map of default Validators",
 			m: map[MessageType]Validator{
-				SimpleEventMessageType: AlwaysInvalid,
+				SimpleEventMessageType: AlwaysInvalid(),
 			},
 			defaultValidator: Validators{},
 			msg:              Message{Type: CreateMessageType},
@@ -163,9 +163,9 @@ func testTypeValidatorValidate(t *testing.T) {
 		{
 			description: "Found error",
 			m: map[MessageType]Validator{
-				SimpleEventMessageType: AlwaysInvalid,
+				SimpleEventMessageType: AlwaysInvalid(),
 			},
-			defaultValidator: AlwaysValid,
+			defaultValidator: AlwaysValid(),
 			msg:              Message{Type: SimpleEventMessageType},
 			expectedErr:      ErrInvalidMsgType,
 		},
@@ -180,7 +180,7 @@ func testTypeValidatorValidate(t *testing.T) {
 		{
 			description: "Unfound error",
 			m: map[MessageType]Validator{
-				SimpleEventMessageType: AlwaysValid,
+				SimpleEventMessageType: AlwaysValid(),
 			},
 			msg:         Message{Type: CreateMessageType},
 			expectedErr: ErrInvalidMsgType,
@@ -188,7 +188,7 @@ func testTypeValidatorValidate(t *testing.T) {
 		{
 			description: "Unfound error, nil default Validators",
 			m: map[MessageType]Validator{
-				SimpleEventMessageType: AlwaysInvalid,
+				SimpleEventMessageType: AlwaysInvalid(),
 			},
 			defaultValidator: nil,
 			msg:              Message{Type: CreateMessageType},
@@ -232,15 +232,15 @@ func testTypeValidatorFactory(t *testing.T) {
 		{
 			description: "Default Validators success",
 			m: map[MessageType]Validator{
-				SimpleEventMessageType: AlwaysValid,
+				SimpleEventMessageType: AlwaysValid(),
 			},
-			defaultValidator: AlwaysValid,
+			defaultValidator: AlwaysValid(),
 			expectedErr:      nil,
 		},
 		{
 			description: "Omit default Validators success",
 			m: map[MessageType]Validator{
-				SimpleEventMessageType: AlwaysValid,
+				SimpleEventMessageType: AlwaysValid(),
 			},
 			expectedErr: nil,
 		},
@@ -248,7 +248,7 @@ func testTypeValidatorFactory(t *testing.T) {
 		{
 			description:      "Nil map of Validators error",
 			m:                nil,
-			defaultValidator: AlwaysValid,
+			defaultValidator: AlwaysValid(),
 			expectedErr:      ErrInvalidValidator,
 		},
 	}
@@ -347,7 +347,7 @@ func testAlwaysValid(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
-			err := AlwaysValid.Validate(tc.msg)
+			err := AlwaysValid().Validate(tc.msg)
 			assert.NoError(err)
 		})
 	}
@@ -429,7 +429,7 @@ func testAlwaysInvalid(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
-			err := AlwaysInvalid.Validate(tc.msg)
+			err := AlwaysInvalid().Validate(tc.msg)
 			assert.ErrorIs(err, ErrInvalidMsgType)
 		})
 	}

--- a/validator_test.go
+++ b/validator_test.go
@@ -307,7 +307,6 @@ func testAlwaysValid(t *testing.T) {
 				SessionID:               "sessionID123",
 			},
 		},
-		// Failure case
 		{
 			description: "Filled message success",
 			msg: Message{


### PR DESCRIPTION
## Overview

related to #25, #78, xmidt-org/scytale#88, xmidt-org/talaria#153 and builds on top of #80.

### tl;dr
This pr introduces our wrp `spec validators` built with our validation framework introduced in #80 which only validates the opinionated portions of the spec. Clients can leverage these prebuilt validators to validate their messages.

<details>
<summary> Explanation</summary>

* Validates requirements described at https://xmidt.io/docs/wrp/basics/#overarching-guidelines
* Validates requirements described at https://xmidt.io/docs/wrp/basics/#locators
* Validates message type values
* Does not cover validators for a specific message type (future prs)

Clients can leverage our prebuilt validators to validate their messages. One set of these validators are our `spec validators`:
```go
msgv, err := NewTypeValidator(
	// Validates found msg types
	map[MessageType]Validator{
		// Validates opinionated portions of the spec
		SimpleEventMessageType: SpecValidators,
		// Only validates Source and nothing else
		SimpleRequestResponseMessageType: SourceValidator,
	},
	// Validates unfound msg types
	AlwaysInvalid)
if err != nil {
	return
}

foundErrSuccess1 := msgv.Validate(Message{
	Type:        SimpleEventMessageType,
	Source:      "MAC:11:22:33:44:55:66",
	Destination: "MAC:11:22:33:44:55:61",
}) // Found success
foundErrSuccess2 := msgv.Validate(Message{
	Type:        SimpleRequestResponseMessageType,
	Source:      "MAC:11:22:33:44:55:66",
	Destination: "invalid:a-BB-44-55",
}) // Found success
foundErrFailure := msgv.Validate(Message{
	Type:        Invalid0MessageType,
	Source:      "invalid:a-BB-44-55",
	Destination: "invalid:a-BB-44-55",
}) // Found error
unfoundErrFailure := msgv.Validate(Message{Type: CreateMessageType}) // Unfound error
fmt.Println(foundErrSuccess1 == nil, foundErrSuccess2 == nil, foundErrFailure == nil, unfoundErrFailure == nil)
// Output: true true false false
```


</details>

<details>
<summary>Type of Change(s)</summary>

- Non-breaking Enhancement
- All new and existing tests passed.

</details>
