### PR TITLE
FR: QOS Ack Implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix unmarshalling error due to missig metadata fields [#79](https://github.com/xmidt-org/wrp-go/pull/79)
 - Deprecated the concrete message structs, e.g. SimpleEvent
 - Added support for the new qos field.
+- QOS implementation [#93](https://github.com/xmidt-org/wrp-go/pull/93), [#81](https://github.com/xmidt-org/wrp-go/pull/81)
 
 ## [v3.1.3]
 - Fix `500 Invalid WRP content type` for invalid `Accept` headers [#74](https://github.com/xmidt-org/wrp-go/pull/74)

--- a/messages.go
+++ b/messages.go
@@ -203,7 +203,6 @@ func (msg *Message) TransactionKey() string {
 
 // IsQOSAckPart determines whether or not a message can QOS ack.
 func (msg *Message) IsQOSAckPart() bool {
-	// TODO add tests
 	if !msg.Type.SupportsQOSAck() {
 		return false
 	}

--- a/messages.go
+++ b/messages.go
@@ -201,6 +201,22 @@ func (msg *Message) TransactionKey() string {
 	return msg.TransactionUUID
 }
 
+// IsQOSAckPart determines whether or not a message can QOS ack.
+func (msg *Message) IsQOSAckPart() bool {
+	// TODO add tests
+	if !msg.Type.SupportsQOSAck() {
+		return false
+	}
+
+	// https://xmidt.io/docs/wrp/basics/#qos-description-qos
+	switch msg.QualityOfService.Level() {
+	case QOSMedium, QOSHigh, QOSCritical:
+		return true
+	default:
+		return false
+	}
+}
+
 func (msg *Message) Response(newSource string, requestDeliveryResponse int64) Routable {
 	response := *msg
 	response.Destination = msg.Source

--- a/messages_test.go
+++ b/messages_test.go
@@ -397,6 +397,117 @@ func testSimpleEventEncode(t *testing.T, f Format, original SimpleEvent) {
 	assert.Equal(original, decoded)
 }
 
+func TestIsQOSAckPart(t *testing.T) {
+	tests := []struct {
+		description string
+		msg         Message
+		ack         bool
+	}{
+		// Ack case
+		{
+			description: "SimpleEventMessageType QOSMediumValue ack",
+			msg:         Message{Type: SimpleEventMessageType, QualityOfService: QOSMediumValue},
+			ack:         true,
+		},
+		{
+			description: "SimpleEventMessageType QOSHighValue ack",
+			msg:         Message{Type: SimpleEventMessageType, QualityOfService: QOSHighValue},
+			ack:         true,
+		},
+		{
+			description: "SimpleEventMessageType QOSCriticalValue ack",
+			msg:         Message{Type: SimpleEventMessageType, QualityOfService: QOSCriticalValue},
+			ack:         true,
+		},
+		{
+			description: "SimpleEventMessageType above QOS range ack",
+			msg:         Message{Type: SimpleEventMessageType, QualityOfService: QOSCriticalValue + 1},
+			ack:         true,
+		},
+		// No ack case
+		{
+			description: "SimpleEventMessageType below QOS range no ack",
+			msg:         Message{Type: SimpleEventMessageType, QualityOfService: QOSLowValue - 1},
+		},
+		{
+			description: "SimpleEventMessageType QOSLowValue no ack",
+			msg:         Message{Type: SimpleEventMessageType, QualityOfService: QOSLowValue},
+		},
+		{
+			description: "Invalid0MessageType no ack",
+			msg:         Message{Type: Invalid0MessageType, QualityOfService: QOSCriticalValue},
+		},
+		{
+			description: "SimpleRequestResponseMessageType no ack",
+			msg:         Message{Type: SimpleRequestResponseMessageType, QualityOfService: QOSCriticalValue},
+		},
+		{
+			description: "CreateMessageType no ack",
+			msg:         Message{Type: CreateMessageType, QualityOfService: QOSCriticalValue},
+		},
+		{
+			description: "RetrieveMessageType no ack",
+			msg:         Message{Type: RetrieveMessageType, QualityOfService: QOSCriticalValue},
+		},
+		{
+			description: "UpdateMessageType no ack",
+			msg:         Message{Type: UpdateMessageType, QualityOfService: QOSCriticalValue},
+		},
+		{
+			description: "DeleteMessageType no ack",
+			msg:         Message{Type: DeleteMessageType, QualityOfService: QOSCriticalValue},
+		},
+		{
+			description: "ServiceRegistrationMessageType no ack",
+			msg:         Message{Type: ServiceRegistrationMessageType, QualityOfService: QOSCriticalValue},
+		},
+		{
+			description: "ServiceAliveMessageType no ack",
+			msg:         Message{Type: ServiceAliveMessageType, QualityOfService: QOSCriticalValue},
+		},
+		{
+			description: "UnknownMessageType no ack",
+			msg:         Message{Type: UnknownMessageType, QualityOfService: QOSCriticalValue},
+		},
+		{
+			description: "AuthorizationMessageType no ack",
+			msg:         Message{Type: AuthorizationMessageType, QualityOfService: QOSCriticalValue},
+		},
+		{
+			description: "Invalid0MessageType no ack",
+			msg:         Message{Type: Invalid0MessageType, QualityOfService: QOSCriticalValue},
+		},
+		{
+			description: "Invalid1MessageType no ack",
+			msg:         Message{Type: Invalid1MessageType, QualityOfService: QOSCriticalValue},
+		},
+		{
+			description: "lastMessageType no ack",
+			msg:         Message{Type: lastMessageType, QualityOfService: QOSCriticalValue},
+		},
+		{
+			description: "Nonexistent negative MessageType no ack",
+			msg:         Message{Type: -10, QualityOfService: QOSCriticalValue},
+		},
+		{
+			description: "Nonexistent positive MessageType no ack",
+			msg:         Message{Type: lastMessageType + 1, QualityOfService: QOSCriticalValue},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			if tc.ack {
+				assert.True(tc.msg.IsQOSAckPart())
+				return
+			}
+
+			assert.False(tc.msg.IsQOSAckPart())
+		})
+	}
+}
+
 func TestSimpleEvent(t *testing.T) {
 	var messages = []SimpleEvent{
 		{},

--- a/messagetype.go
+++ b/messagetype.go
@@ -49,22 +49,22 @@ const (
 // where applicable).
 func (mt MessageType) SupportsTransaction() bool {
 	switch mt {
-	case Invalid0MessageType:
-		return false
-	case Invalid1MessageType:
-		return false
-	case AuthorizationMessageType:
-		return false
-	case SimpleEventMessageType:
-		return false
-	case ServiceRegistrationMessageType:
-		return false
-	case ServiceAliveMessageType:
-		return false
-	case UnknownMessageType:
-		return false
-	default:
+	case SimpleRequestResponseMessageType, CreateMessageType, RetrieveMessageType, UpdateMessageType, DeleteMessageType:
 		return true
+	default:
+		return false
+	}
+}
+
+// SupportsQOSAck tests if messages of this type are allowed to participate in QOS Ack
+// as specified in https://xmidt.io/docs/wrp/basics/#qos-description-qos .
+// If this method returns false, QOS Ack is foregone.
+func (mt MessageType) SupportsQOSAck() bool {
+	switch mt {
+	case SimpleEventMessageType:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -114,7 +114,7 @@ func init() {
 func StringToMessageType(value string) (MessageType, error) {
 	mt, ok := stringToMessageType[value]
 	if !ok {
-		return MessageType(-1), fmt.Errorf("Invalid message type: %s", value)
+		return MessageType(-1), fmt.Errorf("invalid message type: %s", value)
 	}
 
 	return mt, nil

--- a/messagetype_test.go
+++ b/messagetype_test.go
@@ -74,6 +74,7 @@ func TestMessageTypeSupportsTransaction(t *testing.T) {
 			ServiceAliveMessageType:          false,
 			UnknownMessageType:               false,
 			lastMessageType:                  false,
+			lastMessageType + 1:              false,
 		}
 	)
 
@@ -99,6 +100,7 @@ func TestMessageTypeSupportsQOSAck(t *testing.T) {
 			ServiceAliveMessageType:          false,
 			UnknownMessageType:               false,
 			lastMessageType:                  false,
+			lastMessageType + 1:              false,
 		}
 	)
 

--- a/messagetype_test.go
+++ b/messagetype_test.go
@@ -73,11 +73,37 @@ func TestMessageTypeSupportsTransaction(t *testing.T) {
 			ServiceRegistrationMessageType:   false,
 			ServiceAliveMessageType:          false,
 			UnknownMessageType:               false,
+			lastMessageType:                  false,
 		}
 	)
 
 	for messageType, expected := range expectedSupportsTransaction {
 		assert.Equal(expected, messageType.SupportsTransaction())
+	}
+}
+
+func TestMessageTypeSupportsQOSAck(t *testing.T) {
+	var (
+		assert                 = assert.New(t)
+		expectedSupportsQOSAck = map[MessageType]bool{
+			Invalid0MessageType:              false,
+			Invalid1MessageType:              false,
+			AuthorizationMessageType:         false,
+			SimpleRequestResponseMessageType: false,
+			SimpleEventMessageType:           true,
+			CreateMessageType:                false,
+			RetrieveMessageType:              false,
+			UpdateMessageType:                false,
+			DeleteMessageType:                false,
+			ServiceRegistrationMessageType:   false,
+			ServiceAliveMessageType:          false,
+			UnknownMessageType:               false,
+			lastMessageType:                  false,
+		}
+	)
+
+	for messageType, expected := range expectedSupportsQOSAck {
+		assert.Equal(expected, messageType.SupportsQOSAck())
 	}
 }
 

--- a/qos.go
+++ b/qos.go
@@ -16,6 +16,13 @@ const (
 // type determine what QOSLevel a message has.
 type QOSValue int
 
+const (
+	QOSLowValue QOSValue = iota * 25
+	QOSMediumValue
+	QOSHighValue
+	QOSCriticalValue
+)
+
 // Level determines the QOSLevel for this value.  Negative values are assumed
 // to be QOSLow.  Values higher than the highest value (99) are assumed to
 // be QOSCritical.

--- a/qos_test.go
+++ b/qos_test.go
@@ -22,6 +22,22 @@ func TestQOSValue(t *testing.T) {
 			expected QOSLevel
 		}{
 			{
+				value:    QOSLowValue,
+				expected: QOSLow,
+			},
+			{
+				value:    QOSMediumValue,
+				expected: QOSMedium,
+			},
+			{
+				value:    QOSHighValue,
+				expected: QOSHigh,
+			},
+			{
+				value:    QOSCriticalValue,
+				expected: QOSCritical,
+			},
+			{
 				value:    -1,
 				expected: QOSLow,
 			},


### PR DESCRIPTION
Related to xmidt-org/talaria#228 and xmidt-org/talaria#235
What this includes

- make `SupportsTransaction` easier to read
- add `SupportsQOSAck`
- add `IsQOSAckPart`
- add usefull default qos values
```go
const (
	QOSLowValue QOSValue = iota * 25
	QOSMediumValue
	QOSHighValue
	QOSCriticalValue
)
```
- add `TestMessageTypeSupportsQOSAck`
- improve readability for `SupportsTransaction` and add missing message type case `lastMessageType`
- update error message