### PR TITLE
patch: DecodeEntity doesn't honor contentType

### DIFF
--- a/wrpcontext/contents.go
+++ b/wrpcontext/contents.go
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package wrpcontext
+
+import (
+	"context"
+)
+
+type contextContentsKey struct{}
+
+// Set provides a standard way to add a wrp message to a context.Context. This supports not only wrp.Message
+// but also all the other message types, such as wrp.SimpleRequestResponse
+func SetContents(ctx context.Context, b []byte) context.Context {
+	return context.WithValue(ctx, contextContentsKey{}, b)
+}
+
+// Get a message from a context and return it as type T
+func GetContents(ctx context.Context) ([]byte, bool) {
+	src := ctx.Value(contextContentsKey{})
+	if src == nil {
+		return []byte{}, false
+	}
+
+	return get[[]byte](ctx, src)
+}

--- a/wrpcontext/context.go
+++ b/wrpcontext/context.go
@@ -8,21 +8,8 @@ import (
 	"reflect"
 )
 
-type contextKey struct{}
-
-// Set provides a standard way to add a wrp message to a context.Context. This supports not only wrp.Message
-// but also all the other message types, such as wrp.SimpleRequestResponse
-func Set(ctx context.Context, msg any) context.Context {
-	return context.WithValue(ctx, contextKey{}, msg)
-}
-
 // Get a message from a context and return it as type T
-func Get[T any](ctx context.Context) (dest T, ok bool) {
-	src := ctx.Value(contextKey{})
-	if src == nil {
-		return
-	}
-
+func get[T any](ctx context.Context, src any) (dest T, ok bool) {
 	// if src and dest are the exact same type
 	if dest, ok = src.(T); ok {
 		return

--- a/wrpcontext/message.go
+++ b/wrpcontext/message.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package wrpcontext
+
+import (
+	"context"
+
+	"github.com/xmidt-org/wrp-go/v3"
+)
+
+type contextWRPMessageKey struct{}
+
+// Set provides a standard way to add a wrp message to a context.Context. This supports not only wrp.Message
+// but also all the other message types, such as wrp.SimpleRequestResponse
+func SetMessage(ctx context.Context, msg any) context.Context {
+	return context.WithValue(ctx, contextWRPMessageKey{}, msg)
+}
+
+// Get a message from a context and return it as type T
+func GetMessage(ctx context.Context) (*wrp.Message, bool) {
+	src := ctx.Value(contextWRPMessageKey{})
+	if src == nil {
+		return nil, false
+	}
+
+	return get[*wrp.Message](ctx, src)
+}

--- a/wrphttp/decoders.go
+++ b/wrphttp/decoders.go
@@ -96,7 +96,7 @@ func DecodeRequestHeaders(ctx context.Context, original *http.Request) (*Entity,
 
 // DecodeRequest is a Decoder that provides lower-level way of decoding an *http.Request
 // Can work for servers that don't use a wrp.Handler
-func DecodeRequest(r *http.Request, msg any) (*http.Request, error) {
+func DecodeRequest(r *http.Request, _ any) (*http.Request, error) {
 
 	if _, ok := wrpcontext.GetMessage(r.Context()); ok {
 		// Context already contains a message, so just return the original request

--- a/wrphttp/decoders_test.go
+++ b/wrphttp/decoders_test.go
@@ -234,7 +234,7 @@ func testDecodeRequestSuccess(t *testing.T) {
 		)
 
 		require.NoError(
-			wrp.NewEncoderBytes(&body, record.bodyFormat).Encode(&expected),
+			wrp.NewEncoderBytes(&body, record.bodyFormat).Encode(expected),
 		)
 
 		request := httptest.NewRequest("POST", "/", bytes.NewBuffer(body))
@@ -246,15 +246,14 @@ func testDecodeRequestSuccess(t *testing.T) {
 			expected.Type = record.msgType
 		}
 
-		var msg wrp.Message
-		actual, err := DecodeRequest(request, &msg)
-		msg, ok := wrpcontext.Get[wrp.Message](actual.Context())
+		actual, err := DecodeRequest(request, nil)
+		msg, ok := wrpcontext.GetMessage(actual.Context())
 
 		assert.True(ok)
 		assert.Nil(err)
 		require.NotNil(actual)
 		require.NotNil(actual.Context())
-		assert.Equal(expected, &msg)
+		assert.Equal(expected, msg)
 
 	}
 }


### PR DESCRIPTION
The issue lie's in this section:
https://github.com/xmidt-org/wrp-go/blob/e3db47f9274acafc0635b6052d3d32d931ed37c9/wrphttp/decoders.go#L45-L57

Where it sets `entity.Bytes` to a set of json bytes instead of honoring the content-type `format`

This eventually becomes a problem when a user sends a msgpack request to talaria and the device receiving that message then expects a msgpack request body... triggering a decoding error on the device's end

Because candlelight eats the request body when it extracts the wrp message:
https://github.com/xmidt-org/wrp-go/blob/e3db47f9274acafc0635b6052d3d32d931ed37c9/wrphttp/decoders.go#L111-L140

the solution appears to be to save the request body in the context along with the wrp message. This allows us to keep the api changes to a minimum without introducing larger patch 

This patch will require a one liner update to candlelight and scytale.