### PR TITLE
updated getMessageType return to LastMessageType

### DIFF
--- a/messages_test.go
+++ b/messages_test.go
@@ -469,7 +469,7 @@ func TestIsQOSAckPart(t *testing.T) {
 		},
 		{
 			description: "lastMessageType no ack",
-			msg:         Message{Type: lastMessageType, QualityOfService: QOSCriticalValue},
+			msg:         Message{Type: LastMessageType, QualityOfService: QOSCriticalValue},
 		},
 		{
 			description: "Nonexistent negative MessageType no ack",
@@ -477,7 +477,7 @@ func TestIsQOSAckPart(t *testing.T) {
 		},
 		{
 			description: "Nonexistent positive MessageType no ack",
-			msg:         Message{Type: lastMessageType + 1, QualityOfService: QOSCriticalValue},
+			msg:         Message{Type: LastMessageType + 1, QualityOfService: QOSCriticalValue},
 		},
 	}
 

--- a/messagetype.go
+++ b/messagetype.go
@@ -26,7 +26,7 @@ const (
 	ServiceRegistrationMessageType
 	ServiceAliveMessageType
 	UnknownMessageType
-	lastMessageType
+	LastMessageType
 )
 
 // RequiresTransaction tests if messages of this type are allowed to participate in transactions.
@@ -69,8 +69,8 @@ var (
 )
 
 func init() {
-	stringToMessageType = make(map[string]MessageType, lastMessageType-1)
-	friendlyNames = make(map[MessageType]string, lastMessageType-1)
+	stringToMessageType = make(map[string]MessageType, LastMessageType-1)
+	friendlyNames = make(map[MessageType]string, LastMessageType-1)
 	suffixLength := len("MessageType")
 
 	// for each MessageType, allow the following string representations:
@@ -78,7 +78,7 @@ func init() {
 	// The integral value of the constant
 	// The String() value
 	// The String() value minus the MessageType suffix
-	for v := SimpleRequestResponseMessageType; v < lastMessageType; v++ {
+	for v := SimpleRequestResponseMessageType; v < LastMessageType; v++ {
 		stringToMessageType[strconv.Itoa(int(v))] = v
 
 		vs := v.String()
@@ -99,7 +99,7 @@ func init() {
 func StringToMessageType(value string) MessageType {
 	mt, ok := stringToMessageType[value]
 	if !ok {
-		return UnknownMessageType
+		return LastMessageType
 	}
 
 	return mt

--- a/messagetype_string.go
+++ b/messagetype_string.go
@@ -20,7 +20,7 @@ func _() {
 	_ = x[ServiceRegistrationMessageType-9]
 	_ = x[ServiceAliveMessageType-10]
 	_ = x[UnknownMessageType-11]
-	_ = x[lastMessageType-12]
+	_ = x[LastMessageType-12]
 }
 
 const _MessageType_name = "Invalid0MessageTypeInvalid1MessageTypeAuthorizationMessageTypeSimpleRequestResponseMessageTypeSimpleEventMessageTypeCreateMessageTypeRetrieveMessageTypeUpdateMessageTypeDeleteMessageTypeServiceRegistrationMessageTypeServiceAliveMessageTypeUnknownMessageTypelastMessageType"

--- a/messagetype_test.go
+++ b/messagetype_test.go
@@ -59,8 +59,8 @@ func TestMessageTypeSupportsTransaction(t *testing.T) {
 			ServiceRegistrationMessageType:   false,
 			ServiceAliveMessageType:          false,
 			UnknownMessageType:               false,
-			lastMessageType:                  false,
-			lastMessageType + 1:              false,
+			LastMessageType:                  false,
+			LastMessageType + 1:              false,
 		}
 	)
 
@@ -85,8 +85,8 @@ func TestMessageTypeSupportsQOSAck(t *testing.T) {
 			ServiceRegistrationMessageType:   false,
 			ServiceAliveMessageType:          false,
 			UnknownMessageType:               false,
-			lastMessageType:                  false,
-			lastMessageType + 1:              false,
+			LastMessageType:                  false,
+			LastMessageType + 1:              false,
 		}
 	)
 
@@ -115,12 +115,12 @@ func testStringToMessageTypeInvalid(t *testing.T, invalid string) {
 	assert := assert.New(t)
 
 	actual := StringToMessageType(invalid)
-	assert.Equal(UnknownMessageType, actual)
+	assert.Equal(LastMessageType, actual)
 }
 
 func TestStringToMessageType(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
-		for v := SimpleRequestResponseMessageType; v < lastMessageType; v++ {
+		for v := SimpleRequestResponseMessageType; v < LastMessageType; v++ {
 			testStringToMessageTypeValid(t, v)
 		}
 	})

--- a/simpleMessageTypes_validator_test.go
+++ b/simpleMessageTypes_validator_test.go
@@ -101,7 +101,7 @@ func TestSimpleEventValidators(t *testing.T) {
 		{
 			description: "Invaild simple event message error, nonexistent MessageType",
 			msg: Message{
-				Type:        lastMessageType + 1,
+				Type:        LastMessageType + 1,
 				Source:      "dns:external.com",
 				Destination: "MAC:11:22:33:44:55:66",
 			},
@@ -219,7 +219,7 @@ func TestSimpleResponseRequestValidators(t *testing.T) {
 		{
 			description: "Invaild simple request response message error, nonexistent MessageType",
 			msg: Message{
-				Type:        lastMessageType + 1,
+				Type:        LastMessageType + 1,
 				Source:      "dns:external.com",
 				Destination: "MAC:11:22:33:44:55:66",
 			},
@@ -456,7 +456,7 @@ func testSimpleEventTypeValidator(t *testing.T) {
 		},
 		{
 			description: "lastMessageType error",
-			msg:         Message{Type: lastMessageType},
+			msg:         Message{Type: LastMessageType},
 			expectedErr: ErrorNotSimpleEventType,
 		},
 		{
@@ -466,7 +466,7 @@ func testSimpleEventTypeValidator(t *testing.T) {
 		},
 		{
 			description: "Nonexistent positive MessageType error",
-			msg:         Message{Type: lastMessageType + 1},
+			msg:         Message{Type: LastMessageType + 1},
 			expectedErr: ErrorNotSimpleEventType,
 		},
 	}
@@ -562,7 +562,7 @@ func testSimpleResponseRequestTypeValidator(t *testing.T) {
 		},
 		{
 			description: "lastMessageType error",
-			msg:         Message{Type: lastMessageType},
+			msg:         Message{Type: LastMessageType},
 			expectedErr: ErrorNotSimpleResponseRequestType,
 		},
 		{
@@ -572,7 +572,7 @@ func testSimpleResponseRequestTypeValidator(t *testing.T) {
 		},
 		{
 			description: "Nonexistent positive MessageType error",
-			msg:         Message{Type: lastMessageType + 1},
+			msg:         Message{Type: LastMessageType + 1},
 			expectedErr: ErrorNotSimpleResponseRequestType,
 		},
 	}

--- a/spec_validator.go
+++ b/spec_validator.go
@@ -57,12 +57,12 @@ func UTF8Validator(m Message) error {
 
 // MessageTypeValidator takes messages and validates their Type.
 func MessageTypeValidator(m Message) error {
-	if m.Type < Invalid0MessageType || m.Type > lastMessageType {
+	if m.Type < Invalid0MessageType || m.Type > LastMessageType {
 		return ErrorInvalidMessageType
 	}
 
 	switch m.Type {
-	case Invalid0MessageType, Invalid1MessageType, lastMessageType:
+	case Invalid0MessageType, Invalid1MessageType, LastMessageType:
 		return ErrorInvalidMessageType
 	}
 

--- a/spec_validator_test.go
+++ b/spec_validator_test.go
@@ -99,7 +99,7 @@ func TestSpecValidators(t *testing.T) {
 		{
 			description: "Invaild spec error, nonexistent MessageType",
 			msg: Message{
-				Type:        lastMessageType + 1,
+				Type:        LastMessageType + 1,
 				Source:      "dns:external.com",
 				Destination: "MAC:11:22:33:44:55:66",
 			},
@@ -331,7 +331,7 @@ func testMessageTypeValidator(t *testing.T) {
 		},
 		{
 			description: "lastMessageType error",
-			msg:         Message{Type: lastMessageType},
+			msg:         Message{Type: LastMessageType},
 			expectedErr: ErrorInvalidMessageType,
 		},
 		{
@@ -341,7 +341,7 @@ func testMessageTypeValidator(t *testing.T) {
 		},
 		{
 			description: "Nonexistent positive MessageType error",
-			msg:         Message{Type: lastMessageType + 1},
+			msg:         Message{Type: LastMessageType + 1},
 			expectedErr: ErrorInvalidMessageType,
 		},
 	}

--- a/validator_test.go
+++ b/validator_test.go
@@ -409,7 +409,7 @@ func testAlwaysValid(t *testing.T) {
 		{
 			description: "Bad message type success",
 			msg: Message{
-				Type:        lastMessageType + 1,
+				Type:        LastMessageType + 1,
 				Source:      "dns:external.com",
 				Destination: "MAC:11:22:33:44:55:66",
 			},
@@ -491,7 +491,7 @@ func testAlwaysInvalid(t *testing.T) {
 		{
 			description: "Bad message type error",
 			msg: Message{
-				Type:        lastMessageType + 1,
+				Type:        LastMessageType + 1,
 				Source:      "dns:external.com",
 				Destination: "MAC:11:22:33:44:55:66",
 			},

--- a/wrphttp/decoders_test.go
+++ b/wrphttp/decoders_test.go
@@ -175,7 +175,7 @@ func testDecodeRequestHeadersInvalid(t *testing.T) {
 
 	request.Header.Set(MessageTypeHeader, "askdjfa;skdjfasdf")
 	entity, err := DecodeRequestHeaders(context.Background(), request)
-	assert.Equal(wrp.UnknownMessageType, entity.Message.Type)
+	assert.Equal(wrp.LastMessageType, entity.Message.Type)
 	assert.NoError(err)
 }
 

--- a/wrphttp/headers_test.go
+++ b/wrphttp/headers_test.go
@@ -230,7 +230,7 @@ func testNewMessageFromHeadersBadMessageType(t *testing.T) {
 	assert.Error(err)
 
 	message, err = NewMessageFromHeaders(http.Header{MessageTypeHeader: []string{"this could not possibly be a valid message type"}}, nil)
-	assert.Equal(wrp.UnknownMessageType, message.MessageType())
+	assert.Equal(wrp.LastMessageType, message.MessageType())
 	assert.NoError(err)
 }
 


### PR DESCRIPTION
the `MessageTypeValidator` function was not working as expected when returning `UnknownMessageType` from `getMessageType`. Now returning `LastMessageType` instead. 

Related Story: https://github.com/xmidt-org/wrp-go/issues/143