### PR TITLE
Add a scheme of type self.

### DIFF
--- a/id.go
+++ b/id.go
@@ -16,12 +16,13 @@ const (
 	macDelimiters = ":-.,"
 	macLength     = 12
 
-	SchemeMAC    = "mac"
-	SchemeUUID   = "uuid"
-	SchemeDNS    = "dns"
-	SchemeSerial = "serial"
-	SchemeSelf   = "self"
-	SchemeEvent  = "event"
+	SchemeMAC     = "mac"
+	SchemeUUID    = "uuid"
+	SchemeDNS     = "dns"
+	SchemeSerial  = "serial"
+	SchemeSelf    = "self"
+	SchemeEvent   = "event"
+	SchemeUnknown = ""
 )
 
 var (

--- a/id.go
+++ b/id.go
@@ -14,8 +14,14 @@ import (
 const (
 	hexDigits     = "0123456789abcdefABCDEF"
 	macDelimiters = ":-.,"
-	macPrefix     = "mac"
 	macLength     = 12
+
+	SchemeMAC    = "mac"
+	SchemeUUID   = "uuid"
+	SchemeDNS    = "dns"
+	SchemeSerial = "serial"
+	SchemeSelf   = "self"
+	SchemeEvent  = "event"
 )
 
 var (
@@ -24,15 +30,24 @@ var (
 
 	invalidDeviceID = DeviceID("")
 
+	// Locator/DeviceID form:
+	//   {scheme|prefix}:{authority|id}/{service}/{ignored}
+	//
+	//  If the scheme is "mac", "uuid", or "serial" then the authority is the
+	//	device identifier.
+	//  If the scheme is "dns" then the authority is the FQDN of the service.
+	//  If the scheme is "event" then the authority is the event name.
+	//  If the scheme is "self" then the authority is the empty string.
+
 	// DevicIDPattern is the precompiled regular expression that all device identifiers must match.
 	// Matching is partial, as everything after the service is ignored.
 	DeviceIDPattern = regexp.MustCompile(
-		`^(?P<prefix>(?i)mac|uuid|dns|serial):(?P<id>[^/]+)(?P<service>/[^/]+)?`,
+		`^(?P<prefix>(?i)mac|uuid|dns|serial|self):(?P<id>[^/]+)(?P<service>/[^/]+)?`,
 	)
 
 	// LocatorPattern is the precompiled regular expression that all locators must match.
 	LocatorPattern = regexp.MustCompile(
-		`^(?P<scheme>(?i)mac|uuid|dns|serial|event):(?P<authority>[^/]+)(?P<service>/[^/]+)?(?P<ignored>/[^/]+)?`,
+		`^(?P<scheme>(?i)mac|uuid|dns|serial|event|self):(?P<authority>[^/]+)?(?P<service>/[^/]+)?(?P<ignored>/[^/]+)?`,
 	)
 )
 
@@ -85,9 +100,9 @@ func ParseDeviceID(deviceName string) (DeviceID, error) {
 //	{scheme}:{authority}/{service}/{ignored}
 type Locator struct {
 	// Scheme is the scheme type of the locator.  A CPE will have the forms
-	// `mac`, `uuid`, `serial`.  A server or cloud service will have the form
-	// `dns`.  An event locator that is used for pub-sub listeners will have
-	// the form `event`.
+	// `mac`, `uuid`, `serial`, `self`.  A server or cloud service will have
+	// the form `dns`.  An event locator that is used for pub-sub listeners
+	// will have the form `event`.
 	//
 	// The Scheme MUST NOT be used to determine where to send a message, but
 	// rather to determine how to interpret the authority and service.
@@ -133,8 +148,9 @@ func ParseLocator(locator string) (*Locator, error) {
 		l.Ignored = match[4]
 	}
 
+	// If the locator is a device identifier, then we need to parse it.
 	switch l.Scheme {
-	case "mac", "uuid", "serial": // device_id locators
+	case SchemeMAC, SchemeUUID, SchemeSerial, SchemeSelf:
 		id, err := makeDeviceID(l.Scheme, l.Authority)
 		if err != nil {
 			return nil, err
@@ -146,9 +162,14 @@ func ParseLocator(locator string) (*Locator, error) {
 	return &l, nil
 }
 
-// IsDeviceID returns true if the locator is a device identifier.
+// HasDeviceID returns true if the locator is a device identifier.
 func (l Locator) HasDeviceID() bool {
 	return l.ID != ""
+}
+
+// IsSelf returns true if the locator is a self locator.
+func (l Locator) IsSelf() bool {
+	return l.Scheme == SchemeSelf
 }
 
 func (l Locator) String() string {
@@ -171,7 +192,12 @@ func (l Locator) String() string {
 
 func makeDeviceID(prefix, idPart string) (DeviceID, error) {
 	prefix = strings.ToLower(prefix)
-	if prefix == macPrefix {
+	switch prefix {
+	case SchemeSelf:
+		if idPart != "" {
+			return invalidDeviceID, ErrorInvalidDeviceName
+		}
+	case SchemeMAC:
 		var invalidCharacter rune = -1
 		idPart = strings.Map(
 			func(r rune) rune {
@@ -191,6 +217,7 @@ func makeDeviceID(prefix, idPart string) (DeviceID, error) {
 		if invalidCharacter != -1 || len(idPart) != macLength {
 			return invalidDeviceID, ErrorInvalidDeviceName
 		}
+	default:
 	}
 
 	return DeviceID(fmt.Sprintf("%s:%s", prefix, idPart)), nil

--- a/id_test.go
+++ b/id_test.go
@@ -127,7 +127,7 @@ func TestParseLocator(t *testing.T) {
 			locator:     "mac:112233445566",
 			str:         "mac:112233445566",
 			want: &Locator{
-				Scheme:    "mac",
+				Scheme:    SchemeMAC,
 				Authority: "112233445566",
 				ID:        "mac:112233445566",
 			},
@@ -136,7 +136,7 @@ func TestParseLocator(t *testing.T) {
 			locator:     "Mac:112233445566",
 			str:         "mac:112233445566",
 			want: &Locator{
-				Scheme:    "mac",
+				Scheme:    SchemeMAC,
 				Authority: "112233445566",
 				ID:        "mac:112233445566",
 			},
@@ -145,7 +145,7 @@ func TestParseLocator(t *testing.T) {
 			locator:     "DNS:foo.bar.com/service",
 			str:         "dns:foo.bar.com/service",
 			want: &Locator{
-				Scheme:    "dns",
+				Scheme:    SchemeDNS,
 				Authority: "foo.bar.com",
 				Service:   "service",
 			},
@@ -154,10 +154,29 @@ func TestParseLocator(t *testing.T) {
 			locator:     "event:something/service/ignored",
 			str:         "event:something/service/ignored",
 			want: &Locator{
-				Scheme:    "event",
+				Scheme:    SchemeEvent,
 				Authority: "something",
 				Service:   "service",
 				Ignored:   "/ignored",
+			},
+		}, {
+			description: "self locator with service",
+			locator:     "SELF:/service",
+			str:         "self:/service",
+			want: &Locator{
+				Scheme:  SchemeSelf,
+				Service: "service",
+				ID:      "self:",
+			},
+		}, {
+			description: "self locator with service everything",
+			locator:     "self:/service/ignored",
+			str:         "self:/service/ignored",
+			want: &Locator{
+				Scheme:  SchemeSelf,
+				Service: "service",
+				Ignored: "/ignored",
+				ID:      "self:",
 			},
 		},
 
@@ -167,7 +186,7 @@ func TestParseLocator(t *testing.T) {
 			locator:     "dns:foo.bar.com",
 			str:         "dns:foo.bar.com",
 			want: &Locator{
-				Scheme:    "dns",
+				Scheme:    SchemeDNS,
 				Authority: "foo.bar.com",
 			},
 		}, {
@@ -175,7 +194,7 @@ func TestParseLocator(t *testing.T) {
 			locator:     "event:targetedEvent",
 			str:         "event:targetedEvent",
 			want: &Locator{
-				Scheme:    "event",
+				Scheme:    SchemeEvent,
 				Authority: "targetedEvent",
 			},
 		}, {
@@ -183,7 +202,7 @@ func TestParseLocator(t *testing.T) {
 			locator:     "mac:112233445566",
 			str:         "mac:112233445566",
 			want: &Locator{
-				Scheme:    "mac",
+				Scheme:    SchemeMAC,
 				Authority: "112233445566",
 				ID:        "mac:112233445566",
 			},
@@ -192,7 +211,7 @@ func TestParseLocator(t *testing.T) {
 			locator:     "serial:AsdfSerial",
 			str:         "serial:AsdfSerial",
 			want: &Locator{
-				Scheme:    "serial",
+				Scheme:    SchemeSerial,
 				Authority: "AsdfSerial",
 				ID:        "serial:AsdfSerial",
 			},
@@ -201,9 +220,17 @@ func TestParseLocator(t *testing.T) {
 			locator:     "uuid:bbee1f69-2f64-4aa9-a422-27d68b40b152",
 			str:         "uuid:bbee1f69-2f64-4aa9-a422-27d68b40b152",
 			want: &Locator{
-				Scheme:    "uuid",
+				Scheme:    SchemeUUID,
 				Authority: "bbee1f69-2f64-4aa9-a422-27d68b40b152",
 				ID:        "uuid:bbee1f69-2f64-4aa9-a422-27d68b40b152",
+			},
+		}, {
+			description: "self scheme",
+			locator:     "self:",
+			str:         "self:",
+			want: &Locator{
+				Scheme: SchemeSelf,
+				ID:     "self:",
 			},
 		},
 
@@ -218,6 +245,10 @@ func TestParseLocator(t *testing.T) {
 		}, {
 			description: "invalid mac scheme",
 			locator:     "mac:112invalid66",
+			expectedErr: ErrorInvalidDeviceName,
+		}, {
+			description: "invalid self scheme",
+			locator:     "self:anything",
 			expectedErr: ErrorInvalidDeviceName,
 		},
 	}


### PR DESCRIPTION
The self scheme type is a placeholder designed for components that don't know the specific scheme+authority or prefix+id and want to indicate this value must be replaced.