### PR TITLE
feat: new wrp validator, add the ability to validate whether wrp messages' source/dest are not empty

### DIFF
--- a/wrpvalidator/metaValidator.go
+++ b/wrpvalidator/metaValidator.go
@@ -83,10 +83,16 @@ func (v *MetaValidator) UnmarshalJSON(b []byte) error {
 		val = SimpleEventType
 	case SpansType:
 		val = Spans
+	case NoneEmptySourceType:
+		val = NoneEmptySource
+	case NoneEmptyDestinationType:
+		val = NoneEmptyDestination
 	default:
 		return fmt.Errorf("validator `%s`: wrp validator selection: %w: %s", v.meta.Type, ErrValidatorUnmarshalling, errValidatorTypeInvalid)
 	}
 
+	// By default validators will have no metrics.
+	// Metrics are optional and can be added with `MetaValidator.AddMetric()`.
 	v.validator = NewValidatorWithoutMetric(val)
 
 	if !v.IsValid() {
@@ -128,6 +134,10 @@ func (v *MetaValidator) AddMetric(tf *touchstone.Factory, labelNames ...string) 
 		val, err = NewSimpleEventTypeWithMetric(tf, labelNames...)
 	case SpansType:
 		val, err = NewSpansWithMetric(tf, labelNames...)
+	case NoneEmptySourceType:
+		val, err = NewNoneEmptySourceWithMetric(tf, labelNames...)
+	case NoneEmptyDestinationType:
+		val, err = NewNoneEmptyDestinationWithMetric(tf, labelNames...)
 		// no default is needed since v.IsValid() takes care of this case
 	}
 

--- a/wrpvalidator/metaValidator_test.go
+++ b/wrpvalidator/metaValidator_test.go
@@ -267,6 +267,24 @@ func TestMetaValidatorAddMetric(t *testing.T) {
 			]`),
 		},
 		{
+			description: "Add metric validator NoneEmptySource",
+			config: []byte(`[
+				{
+					"type": "none_empty_source",
+					"level": "warning"
+				}
+			]`),
+		},
+		{
+			description: "Add metric validator NoneEmptyDestinationType",
+			config: []byte(`[
+				{
+					"type": "none_empty_destination",
+					"level": "warning"
+				}
+			]`),
+		},
+		{
 			description: "Add metric validator always_invalid",
 			config: []byte(`[
 				{

--- a/wrpvalidator/metrics.go
+++ b/wrpvalidator/metrics.go
@@ -12,53 +12,65 @@ const (
 	// MetricPrefix is prepended to all metrics exposed by this package.
 	metricPrefix = "wrp_validator_"
 
-	// alwaysInvalidValidatorErrorTotalName is the name of the counter for all AlwaysInvalid validation.
+	// alwaysInvalidValidatorErrorTotalName is the name of the counter for all AlwaysInvalid validation errors.
 	alwaysInvalidValidatorErrorTotalName = metricPrefix + "always_invalid"
 
 	// alwaysInvalidValidatorErrorTotalHelp is the help text for the AlwaysInvalid metric.
 	alwaysInvalidValidatorErrorTotalHelp = "the total number of AlwaysInvalid validations"
 
-	// destinationValidatorErrorTotalName is the name of the counter for all destination validation.
+	// destinationValidatorErrorTotalName is the name of the counter for all destination validation errors.
 	destinationValidatorErrorTotalName = metricPrefix + "destination"
 
 	// destinationValidatorErrorTotalHelp is the help text for the Destination metric.
-	destinationValidatorErrorTotalHelp = "the total number of Destination metric"
+	destinationValidatorErrorTotalHelp = "the total number of Destination validation errors"
 
-	// sourceValidatorErrorTotalName is the name of the counter for all source validation.
+	// sourceValidatorErrorTotalName is the name of the counter for all source validation errors.
 	sourceValidatorErrorTotalName = metricPrefix + "source"
 
 	// sourceValidatorErrorTotalHelp is the help text for the Source metric.
-	sourceValidatorErrorTotalHelp = "the total number of Source metric"
+	sourceValidatorErrorTotalHelp = "the total number of Source validation errors"
 
-	// messageTypeValidatorErrorTotalName is the name of the counter for all MessageType validation.
+	// messageTypeValidatorErrorTotalName is the name of the counter for all MessageType validation errors.
 	messageTypeValidatorErrorTotalName = metricPrefix + "message_type"
 
 	// messageTypeValidatorErrorTotalHelp is the help text for the MessageType metric.
-	messageTypeValidatorErrorTotalHelp = "the total number of MessageType metric"
+	messageTypeValidatorErrorTotalHelp = "the total number of MessageType validation errors"
 
-	// utf8ValidatorErrorTotalName is the name of the counter for all UTF8 validation.
+	// utf8ValidatorErrorTotalName is the name of the counter for all UTF8 validation errors.
 	utf8ValidatorErrorTotalName = metricPrefix + "utf8"
 
 	// utf8ValidatorErrorTotalHelp is the help text for the UTF8 Validator metric.
-	utf8ValidatorErrorTotalHelp = "the total number of UTF8 Validator metric"
+	utf8ValidatorErrorTotalHelp = "the total number of UTF8 validation errors"
 
-	// simpleEventTypeValidatorErrorTotalName is the name of the counter for all SimpleEventType validation.
+	// simpleEventTypeValidatorErrorTotalName is the name of the counter for all SimpleEventType validation errors.
 	simpleEventTypeValidatorErrorTotalName = metricPrefix + "simple_event_type"
 
 	// simpleEventTypeValidatorErrorTotalHelp is the help text for the SimpleEventType Validator metric.
-	simpleEventTypeValidatorErrorTotalHelp = "the total number of SimpleEventType Validator metric"
+	simpleEventTypeValidatorErrorTotalHelp = "the total number of SimpleEventType validation errors"
 
-	// simpleRequestResponseMessageTypeErrorTotalName is the name of the counter for all SimpleRequestResponseMessageType validation.
+	// simpleRequestResponseMessageTypeErrorTotalName is the name of the counter for all SimpleRequestResponseMessageType validation errors.
 	simpleRequestResponseMessageTypeErrorTotalName = metricPrefix + "simple_request_response_message_type"
 
 	// simpleRequestResponseMessageTypeErrorTotalHelp is the help text for the SimpleRequestResponseMessageType Validator metric.
-	simpleRequestResponseMessageTypeErrorTotalHelp = "the total number of SimpleRequestResponseMessageType Validator metric"
+	simpleRequestResponseMessageTypeErrorTotalHelp = "the total number of SimpleRequestResponseMessageType validation errors"
 
-	// spansValidatorErrorTotalName is the name of the counter for all Spans validation.
+	// spansValidatorErrorTotalName is the name of the counter for all Spans validation errors.
 	spansValidatorErrorTotalName = metricPrefix + "spans"
 
 	// spansValidatorErrorTotalHelp is the help text for the Spans Validator metric.
-	spansValidatorErrorTotalHelp = "the total number of Spans Validator metric"
+	spansValidatorErrorTotalHelp = "the total number of Spans validation errors"
+
+	// noneEmptySourceErrorTotalName is the name of the counter for all noneEmptySource validation errors.
+	noneEmptySourceErrorTotalName = metricPrefix + "none_empty_source"
+
+	// noneEmptySourceErrorTotalHelp is the help text for the noneEmptySource Validator metric.
+	noneEmptySourceErrorTotalHelp = "the total number of None Empty Source validation errors"
+
+	// noneEmptyDestinationErrorTotalName is the name of the counter for all noneEmptyDestination validation errors.
+	noneEmptyDestinationErrorTotalName = metricPrefix + "none_empty_destination"
+
+	// noneEmptyDestinationErrorTotalHelp is the help text for the noneEmptyDestination Validator metric.
+	noneEmptyDestinationErrorTotalHelp = "the total number of None Empty Destination validation errors"
 )
 
 // Metric label names
@@ -143,6 +155,26 @@ func newSpansErrorTotal(tf *touchstone.Factory, labelNames ...string) (m *promet
 		prometheus.CounterOpts{
 			Name: spansValidatorErrorTotalName,
 			Help: spansValidatorErrorTotalHelp,
+		},
+		labelNames...,
+	)
+}
+
+func newNoneEmptySourceErrorTotal(tf *touchstone.Factory, labelNames ...string) (m *prometheus.CounterVec, err error) {
+	return tf.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: noneEmptySourceErrorTotalName,
+			Help: noneEmptySourceErrorTotalHelp,
+		},
+		labelNames...,
+	)
+}
+
+func newNoneEmptyDestinationErrorTotal(tf *touchstone.Factory, labelNames ...string) (m *prometheus.CounterVec, err error) {
+	return tf.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: noneEmptyDestinationErrorTotalName,
+			Help: noneEmptyDestinationErrorTotalHelp,
 		},
 		labelNames...,
 	)

--- a/wrpvalidator/validatorType.go
+++ b/wrpvalidator/validatorType.go
@@ -23,6 +23,10 @@ const (
 	SimpleResponseRequestTypeType
 	SimpleEventTypeType
 	SpansType
+	// Add-ons
+	NoneEmptySourceType
+	NoneEmptyDestinationType
+	// End of list.
 	lastType
 )
 
@@ -40,6 +44,9 @@ var (
 		"simple_res_req": SimpleResponseRequestTypeType,
 		"simple_event":   SimpleEventTypeType,
 		"spans":          SpansType,
+		// Add-ons
+		"none_empty_source":      NoneEmptySourceType,
+		"none_empty_destination": NoneEmptyDestinationType,
 	}
 	validatorTypeMarshal = map[validatorType]string{
 		UnknownType:                   "unknown",
@@ -52,6 +59,9 @@ var (
 		SimpleResponseRequestTypeType: "simple_res_req",
 		SimpleEventTypeType:           "simple_event",
 		SpansType:                     "spans",
+		// Add-ons
+		NoneEmptySourceType:      "none_empty_source",
+		NoneEmptyDestinationType: "none_empty_destination",
 	}
 )
 

--- a/wrpvalidator/validatorType_test.go
+++ b/wrpvalidator/validatorType_test.go
@@ -56,6 +56,14 @@ func TestTypeUnmarshalling(t *testing.T) {
 			config:      []byte("spans"),
 		},
 		{
+			description: "NoneEmptySourceType valid",
+			config:      []byte("none_empty_source"),
+		},
+		{
+			description: "NoneEmptyDestinationType valid",
+			config:      []byte("none_empty_destination"),
+		},
+		{
 			description: "Nonexistent type invalid",
 			config:      []byte("FOOBAR"),
 			invalid:     true,
@@ -138,6 +146,16 @@ func TestTypeState(t *testing.T) {
 			description: "SpansType valid",
 			val:         SpansType,
 			expectedVal: "spans",
+		},
+		{
+			description: "NoneEmptySourceType valid",
+			val:         NoneEmptySourceType,
+			expectedVal: "none_empty_source",
+		},
+		{
+			description: "NoneEmptyDestinationType valid",
+			val:         NoneEmptyDestinationType,
+			expectedVal: "none_empty_destination",
 		},
 		{
 			description: "lastLevel valid",


### PR DESCRIPTION
- new wrp validators: none_empty_destination & none_empty_source
  - validates whether wrp messages' source/dest are not empty
  - includes metrics for the new validator

other things included:
- fix doc typos
- improve metric help docs