### PR TITLE
patch: ParseLocator, sanitize locator components

### DIFF
--- a/id.go
+++ b/id.go
@@ -141,13 +141,13 @@ func ParseLocator(locator string) (Locator, error) {
 
 	var l Locator
 
-	l.Scheme = strings.ToLower(match[1])
-	l.Authority = match[2]
+	l.Scheme = strings.TrimSpace(strings.ToLower(match[1]))
+	l.Authority = strings.TrimSpace(match[2])
 	if len(match) > 3 {
-		l.Service = strings.TrimPrefix(match[3], "/")
+		l.Service = strings.TrimSpace(strings.TrimPrefix(match[3], "/"))
 	}
 	if len(match) > 4 {
-		l.Ignored = match[4]
+		l.Ignored = strings.TrimSpace(match[4])
 	}
 
 	// If the locator is a device identifier, then we need to parse it.

--- a/id_test.go
+++ b/id_test.go
@@ -191,6 +191,14 @@ func TestParseLocator(t *testing.T) {
 				Authority: "foo.bar.com",
 			},
 		}, {
+			description: "event scheme (with spaces)",
+			locator:     "event:   targetedEvent     ",
+			str:         "event:targetedEvent",
+			want: Locator{
+				Scheme:    SchemeEvent,
+				Authority: "targetedEvent",
+			},
+		}, {
 			description: "event scheme",
 			locator:     "event:targetedEvent",
 			str:         "event:targetedEvent",
@@ -251,6 +259,14 @@ func TestParseLocator(t *testing.T) {
 			description: "invalid self scheme",
 			locator:     "self:anything",
 			expectedErr: ErrorInvalidDeviceName,
+		}, {
+			description: "invalid event scheme (no authority)",
+			locator:     "event:/anything",
+			expectedErr: ErrorInvalidLocator,
+		}, {
+			description: "invalid event scheme (no authority and with spaces)",
+			locator:     "event:    /anything",
+			expectedErr: ErrorInvalidLocator,
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
- currently, parsing the following string "event:     /xmidt-test/2/config" yields an authority with the value `     `
 - sanitize each locator component, removing trailing and leading whitespaces